### PR TITLE
[Admin] admin 메인 페이지 구성

### DIFF
--- a/apps/admin/src/app/page.tsx
+++ b/apps/admin/src/app/page.tsx
@@ -1,10 +1,5 @@
-import { Button as BTN, Test } from 'shared';
+import { MainPage } from 'admin/pageContainer';
 
 export default function Home() {
-  return (
-    <>
-      <BTN>button1</BTN>
-      <Test>Test</Test>
-    </>
-  );
+  return <MainPage />;
 }

--- a/apps/admin/src/components/ApplicantTH/index.tsx
+++ b/apps/admin/src/components/ApplicantTH/index.tsx
@@ -1,5 +1,4 @@
 import { QuestionMark } from 'admin/assets';
-import { ApplicantTR } from 'admin/components';
 
 import { Table, TableBody, TableCell, TableRow } from 'shared/components';
 import { cn } from 'shared/lib/utils';
@@ -30,7 +29,6 @@ const ApplicantTH = () => {
           </TableRow>
         </TableBody>
       </Table>
-      <ApplicantTR />
     </>
   );
 };

--- a/apps/admin/src/components/ApplicantTR/index.tsx
+++ b/apps/admin/src/components/ApplicantTR/index.tsx
@@ -13,7 +13,9 @@ import { useDebounce } from 'shared/hooks';
 import { cn } from 'shared/lib/utils';
 import { formatScore } from 'shared/utils';
 
-const ApplicantTR = () => {
+import { OneseoType } from 'types/oneseo';
+
+const ApplicantTR = ({}: OneseoType) => {
   const example직무적성처리시작일자 = new Date('2024-07-31');
   const example심층면접처리시작일자 = new Date('2024-08-30');
 

--- a/apps/admin/src/components/FilterBar/index.tsx
+++ b/apps/admin/src/components/FilterBar/index.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import { SearchIcon, PrintIcon, FileIcon } from 'admin/assets';
 
 import {

--- a/apps/admin/src/components/SideMenu/index.tsx
+++ b/apps/admin/src/components/SideMenu/index.tsx
@@ -90,7 +90,7 @@ const SideMenu = ({ isOpen, setIsOpen }: SideMenuProps) => {
         'flex',
         'flex-col',
         'justify-between',
-        'absolute',
+        'fixed',
         !isOpen && 'translate-x-[-200px]',
         'ease-in-out',
         'duration-150',

--- a/apps/admin/src/components/SideMenu/index.tsx
+++ b/apps/admin/src/components/SideMenu/index.tsx
@@ -71,8 +71,12 @@ const ManageTypeArray = [
   },
 ] as const;
 
-const SideMenu = () => {
-  const [isOpen, setIsOpen] = useState<boolean>(true);
+interface SideMenuProps {
+  isOpen: boolean;
+  setIsOpen: React.Dispatch<React.SetStateAction<boolean>>;
+}
+
+const SideMenu = ({ isOpen, setIsOpen }: SideMenuProps) => {
   const [selectedIndex, setSelectedIndex] = useState<number>(0);
 
   return (
@@ -91,6 +95,8 @@ const SideMenu = () => {
         'ease-in-out',
         'duration-150',
         'transition-all',
+        'left-0',
+        'top-0',
       )}
     >
       <div className={cn('flex', 'flex-col', 'gap-10')}>

--- a/apps/admin/src/components/index.ts
+++ b/apps/admin/src/components/index.ts
@@ -3,3 +3,4 @@ export { default as ApplicantTH } from './ApplicantTH';
 export { default as ApplicantTR } from './ApplicantTR';
 export { default as TextField } from './TextField';
 export { default as FilterBar } from './FilterBar';
+export { default as SideMenu } from './SideMenu';

--- a/apps/admin/src/pageContainer/MainPage/index.tsx
+++ b/apps/admin/src/pageContainer/MainPage/index.tsx
@@ -1,0 +1,23 @@
+import { PaginationExample } from 'shared';
+
+import { SideMenu } from 'admin/components';
+
+import { cn } from 'shared/lib/utils';
+
+const LoginPage = () => {
+  const flexColStyle = ['flex', 'flex-col'] as const;
+
+  return (
+    <main className={cn('ml-60', 'pw-40', 'pt-[60px]', 'pb-8')}>
+      <SideMenu />
+      <div className={cn(...flexColStyle, 'gap-8')}>
+        <h1 className={cn('text-gray-900', 'text-3xl', 'font-semibold')}>전체 지원자 관리</h1>
+        <div className={cn(...flexColStyle, 'gap-5')}>
+          <PaginationExample />
+        </div>
+      </div>
+    </main>
+  );
+};
+
+export default LoginPage;

--- a/apps/admin/src/pageContainer/MainPage/index.tsx
+++ b/apps/admin/src/pageContainer/MainPage/index.tsx
@@ -7,7 +7,7 @@ import { SideMenu, FilterBar, ApplicantTH, ApplicantTR } from 'admin/components'
 import { PaginationExample } from 'shared/components';
 import { cn } from 'shared/lib/utils';
 
-const PER_PAGE = 10 as const;
+const PER_PAGE = 10;
 
 const MockApplicationList = Array.from({ length: 50 }, (_, index) => {
   return {

--- a/apps/admin/src/pageContainer/MainPage/index.tsx
+++ b/apps/admin/src/pageContainer/MainPage/index.tsx
@@ -9,7 +9,7 @@ import { cn } from 'shared/lib/utils';
 
 const PER_PAGE = 10 as const;
 
-const MockApplicationList = new Array(50).fill(0).map((application, index) => {
+const MockApplicationList = Array.from({ length: 50 }, (_, index) => {
   return {
     applicantId: '0189' + index,
     applicantName: '신희성',

--- a/apps/admin/src/pageContainer/MainPage/index.tsx
+++ b/apps/admin/src/pageContainer/MainPage/index.tsx
@@ -7,6 +7,29 @@ import { SideMenu, FilterBar, ApplicantTH, ApplicantTR } from 'admin/components'
 import { PaginationExample } from 'shared/components';
 import { cn } from 'shared/lib/utils';
 
+const PER_PAGE = 10 as const;
+
+const MockApplicationList = new Array(50).fill(0).map((application, index) => {
+  return {
+    applicantId: '0189' + index,
+    applicantName: '신희성',
+    graduation: 'CANDIDATE',
+    applicantPhoneNumber: '010 1234 5678',
+    guardianPhoneNumber: '010 1234 5678',
+    teacherName: '김선생',
+    teacherPhoneNumber: '010 1234 5678',
+    isFinalSubmitted: false,
+    isPrintsArrived: false,
+    firstEvaluation: '미정',
+    secondEvaluation: '미정',
+    screeningFirstEvaluationAt: 'GENERAL',
+    screeningSecondEvaluationAt: 'GENERAL',
+    registrationNumber: 100,
+    secondScore: 100.0,
+    interviewScore: 100.0,
+  };
+});
+
 const LoginPage = () => {
   const flexColStyle = ['flex', 'flex-col'] as const;
 
@@ -21,18 +44,19 @@ const LoginPage = () => {
           <FilterBar />
           <div
             className={cn(
-              'w-full',
-              'rounded-t-md',
-              'overflow-hidden',
               'border',
               'border-solid',
               'border-zinc-200',
+              'w-full',
+              'rounded-t-md',
+              'overflow-hidden',
             )}
           >
             <ApplicantTH />
-            <ApplicantTR />
-            <ApplicantTR />
-            <ApplicantTR />
+            <div className={cn('bg-zinc-200', 'w-full', 'h-[1px]')} />
+            {MockApplicationList.slice(0, PER_PAGE).map((application) => (
+              <ApplicantTR key={application.applicantId} />
+            ))}
           </div>
           <PaginationExample />
         </div>

--- a/apps/admin/src/pageContainer/MainPage/index.tsx
+++ b/apps/admin/src/pageContainer/MainPage/index.tsx
@@ -1,18 +1,39 @@
-import { PaginationExample } from 'shared';
+'use client';
 
-import { SideMenu } from 'admin/components';
+import { useState } from 'react';
 
+import { SideMenu, FilterBar, ApplicantTH, ApplicantTR } from 'admin/components';
+
+import { PaginationExample } from 'shared/components';
 import { cn } from 'shared/lib/utils';
 
 const LoginPage = () => {
   const flexColStyle = ['flex', 'flex-col'] as const;
 
+  const [isOpen, setIsOpen] = useState<boolean>(true);
+
   return (
-    <main className={cn('ml-60', 'pw-40', 'pt-[60px]', 'pb-8')}>
-      <SideMenu />
+    <main className={cn(isOpen && 'ml-60', isOpen ? 'px-10' : 'pl-20 pr-10', 'pt-[60px]', 'pb-8')}>
+      <SideMenu isOpen={isOpen} setIsOpen={setIsOpen} />
       <div className={cn(...flexColStyle, 'gap-8')}>
         <h1 className={cn('text-gray-900', 'text-3xl', 'font-semibold')}>전체 지원자 관리</h1>
         <div className={cn(...flexColStyle, 'gap-5')}>
+          <FilterBar />
+          <div
+            className={cn(
+              'w-full',
+              'rounded-t-md',
+              'overflow-hidden',
+              'border',
+              'border-solid',
+              'border-zinc-200',
+            )}
+          >
+            <ApplicantTH />
+            <ApplicantTR />
+            <ApplicantTR />
+            <ApplicantTR />
+          </div>
           <PaginationExample />
         </div>
       </div>

--- a/apps/admin/src/pageContainer/MainPage/index.tsx
+++ b/apps/admin/src/pageContainer/MainPage/index.tsx
@@ -7,26 +7,25 @@ import { SideMenu, FilterBar, ApplicantTH, ApplicantTR } from 'admin/components'
 import { PaginationExample } from 'shared/components';
 import { cn } from 'shared/lib/utils';
 
+import { OneseoType } from 'types/oneseo';
+
 const PER_PAGE = 10;
 
-const MockApplicationList = Array.from({ length: 50 }, (_, index) => {
+const MockApplicationList: OneseoType[] = Array.from({ length: 50 }, (_, index) => {
   return {
-    applicantId: '0189' + index,
-    applicantName: '신희성',
-    graduation: 'CANDIDATE',
-    applicantPhoneNumber: '010 1234 5678',
-    guardianPhoneNumber: '010 1234 5678',
-    teacherName: '김선생',
-    teacherPhoneNumber: '010 1234 5678',
-    isFinalSubmitted: false,
-    isPrintsArrived: false,
-    firstEvaluation: '미정',
-    secondEvaluation: '미정',
-    screeningFirstEvaluationAt: 'GENERAL',
-    screeningSecondEvaluationAt: 'GENERAL',
-    registrationNumber: 100,
-    secondScore: 100.0,
-    interviewScore: 100.0,
+    memberId: index,
+    submitCode: 'A-1',
+    realOneseoArrivedYn: 'YES',
+    name: '신희성',
+    screening: 'GENERAL',
+    schoolName: 'SW중학교',
+    phoneNumber: '010 1234 1234',
+    guardianPhoneNumber: '010 1234 1234',
+    schoolTeacherPhoneNumber: '010 1234 1234',
+    firstTestPassYn: 'YES',
+    aptitudeEvaluationScore: 100,
+    interviewScore: 100,
+    secondTestPassYn: 'YES',
   };
 });
 
@@ -55,7 +54,7 @@ const LoginPage = () => {
             <ApplicantTH />
             <div className={cn('bg-zinc-200', 'w-full', 'h-[1px]')} />
             {MockApplicationList.slice(0, PER_PAGE).map((application) => (
-              <ApplicantTR key={application.applicantId} />
+              <ApplicantTR {...application} key={application.memberId} />
             ))}
           </div>
           <PaginationExample />

--- a/apps/admin/src/pageContainer/index.ts
+++ b/apps/admin/src/pageContainer/index.ts
@@ -1,1 +1,2 @@
 export { default as LoginPage } from './LoginPage';
+export { default as MainPage } from './MainPage';

--- a/apps/admin/tsconfig.json
+++ b/apps/admin/tsconfig.json
@@ -20,7 +20,8 @@
     "paths": {
       "admin/*": ["./src/*"],
       "shared/*": ["../../packages/shared/src/*"],
-      "api/*": ["../../packages/api/src/*"]
+      "api/*": ["../../packages/api/src/*"],
+      "types/*": ["../../packages/types/src/*"]
     }
   },
   "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],

--- a/packages/shared/src/components/index.ts
+++ b/packages/shared/src/components/index.ts
@@ -1,2 +1,2 @@
-export { default as Test } from "./Test";
-export * from "./ui";
+export { default as Test } from './Test';
+export * from './ui';

--- a/packages/shared/src/components/ui/Pagination/index.stories.tsx
+++ b/packages/shared/src/components/ui/Pagination/index.stories.tsx
@@ -1,9 +1,9 @@
-import { PaginationExample } from ".";
+import { PaginationExample } from '.';
 
-import type { Meta, StoryObj } from "@storybook/react";
+import type { Meta, StoryObj } from '@storybook/react';
 
 const meta: Meta<typeof PaginationExample> = {
-  title: "Shared/Pagination",
+  title: 'Shared/Pagination',
   component: PaginationExample,
 };
 

--- a/packages/shared/src/components/ui/Pagination/index.tsx
+++ b/packages/shared/src/components/ui/Pagination/index.tsx
@@ -1,46 +1,47 @@
-import * as React from "react";
-import { ChevronLeft, ChevronRight, MoreHorizontal } from "lucide-react";
+import * as React from 'react';
 
-import { cn } from "shared/lib/utils";
-import { ButtonProps, buttonVariants } from "shared/components/ui/Button";
+import { ChevronLeft, ChevronRight, MoreHorizontal } from 'lucide-react';
 
-const Pagination = ({ className, ...props }: React.ComponentProps<"nav">) => (
+import { ButtonProps, buttonVariants } from 'shared/components/ui/Button';
+import { cn } from 'shared/lib/utils';
+
+const Pagination = ({ className, ...props }: React.ComponentProps<'nav'>) => (
   <nav
     role="navigation"
     aria-label="pagination"
-    className={cn("mx-auto", "flex w-full", "justify-center", className)}
+    className={cn('mx-auto', 'flex w-full', 'justify-center', className)}
     {...props}
   />
 );
-Pagination.displayName = "Pagination";
+Pagination.displayName = 'Pagination';
 
-const PaginationContent = React.forwardRef<HTMLUListElement, React.ComponentProps<"ul">>(
+const PaginationContent = React.forwardRef<HTMLUListElement, React.ComponentProps<'ul'>>(
   ({ className, ...props }, ref) => (
     <ul
       ref={ref}
-      className={cn("flex", "flex-row", "items-center", "gap-1", className)}
+      className={cn('flex', 'flex-row', 'items-center', 'gap-1', className)}
       {...props}
     />
   ),
 );
-PaginationContent.displayName = "PaginationContent";
+PaginationContent.displayName = 'PaginationContent';
 
-const PaginationItem = React.forwardRef<HTMLLIElement, React.ComponentProps<"li">>(
+const PaginationItem = React.forwardRef<HTMLLIElement, React.ComponentProps<'li'>>(
   ({ className, ...props }, ref) => <li ref={ref} className={cn(className)} {...props} />,
 );
-PaginationItem.displayName = "PaginationItem";
+PaginationItem.displayName = 'PaginationItem';
 
 type PaginationLinkProps = {
   isActive?: boolean;
-} & Pick<ButtonProps, "size"> &
-  React.ComponentProps<"a">;
+} & Pick<ButtonProps, 'size'> &
+  React.ComponentProps<'a'>;
 
-const PaginationLink = ({ className, isActive, size = "icon", ...props }: PaginationLinkProps) => (
+const PaginationLink = ({ className, isActive, size = 'icon', ...props }: PaginationLinkProps) => (
   <a
-    aria-current={isActive ? "page" : undefined}
+    aria-current={isActive ? 'page' : undefined}
     className={cn(
       buttonVariants({
-        variant: isActive ? "outline" : "ghost",
+        variant: isActive ? 'outline' : 'ghost',
         size,
       }),
       className,
@@ -48,7 +49,7 @@ const PaginationLink = ({ className, isActive, size = "icon", ...props }: Pagina
     {...props}
   />
 );
-PaginationLink.displayName = "PaginationLink";
+PaginationLink.displayName = 'PaginationLink';
 
 const PaginationPrevious = ({
   className,
@@ -57,39 +58,39 @@ const PaginationPrevious = ({
   <PaginationLink
     aria-label="Go to previous page"
     size="default"
-    className={cn(buttonVariants({ variant: "ghost", size: "default" }), "gap-1 pl-2.5", className)}
+    className={cn(buttonVariants({ variant: 'ghost', size: 'default' }), 'gap-1 pl-2.5', className)}
     {...props}
   >
     <ChevronLeft className="w-4 h-4" />
     <span>Previous</span>
   </PaginationLink>
 );
-PaginationPrevious.displayName = "PaginationPrevious";
+PaginationPrevious.displayName = 'PaginationPrevious';
 
 const PaginationNext = ({ className, ...props }: React.ComponentProps<typeof PaginationLink>) => (
   <PaginationLink
     aria-label="Go to next page"
     size="default"
-    className={cn(buttonVariants({ variant: "ghost", size: "default" }), "gap-1 pr-2.5", className)}
+    className={cn(buttonVariants({ variant: 'ghost' }), 'gap-1 pr-2.5', className)}
     {...props}
   >
     <span>Next</span>
     <ChevronRight className="w-4 h-4" />
   </PaginationLink>
 );
-PaginationNext.displayName = "PaginationNext";
+PaginationNext.displayName = 'PaginationNext';
 
-const PaginationEllipsis = ({ className, ...props }: React.ComponentProps<"span">) => (
+const PaginationEllipsis = ({ className, ...props }: React.ComponentProps<'span'>) => (
   <span
     aria-hidden
-    className={cn("flex", "h-9", "w-9", "items-center", "justify-center", className)}
+    className={cn('flex', 'h-9', 'w-9', 'items-center', 'justify-center', className)}
     {...props}
   >
-    <MoreHorizontal className={cn("w-4", "h-4")} />
+    <MoreHorizontal className={cn('w-4', 'h-4')} />
     <span className="sr-only">More pages</span>
   </span>
 );
-PaginationEllipsis.displayName = "PaginationEllipsis";
+PaginationEllipsis.displayName = 'PaginationEllipsis';
 
 const PaginationExample = () => {
   return (

--- a/packages/shared/src/components/ui/Pagination/index.tsx
+++ b/packages/shared/src/components/ui/Pagination/index.tsx
@@ -64,7 +64,7 @@ const PaginationPrevious = ({
     {...props}
   >
     <ChevronLeft className="w-4 h-4" />
-    <span>Previous</span>
+    <div className="w-[84px]" />
   </PaginationLink>
 );
 PaginationPrevious.displayName = 'PaginationPrevious';
@@ -76,7 +76,7 @@ const PaginationNext = ({ className, ...props }: React.ComponentProps<typeof Pag
     className={cn(buttonVariants({ variant: 'ghost' }), 'gap-1 pr-2.5', className)}
     {...props}
   >
-    <span>Next</span>
+    <div className="w-[48px]" />
     <ChevronRight className="w-4 h-4" />
   </PaginationLink>
 );

--- a/packages/shared/src/components/ui/Pagination/index.tsx
+++ b/packages/shared/src/components/ui/Pagination/index.tsx
@@ -1,8 +1,10 @@
+'use client';
+
 import * as React from 'react';
 
 import { ChevronLeft, ChevronRight, MoreHorizontal } from 'lucide-react';
 
-import { ButtonProps, buttonVariants } from 'shared/components/ui/Button';
+import { buttonVariants, ButtonProps } from 'shared/components';
 import { cn } from 'shared/lib/utils';
 
 const Pagination = ({ className, ...props }: React.ComponentProps<'nav'>) => (

--- a/packages/types/src/oneseo.ts
+++ b/packages/types/src/oneseo.ts
@@ -8,6 +8,8 @@ export type FreeSemesterType = "1-1" | "1-2" | "2-1" | "2-2" | "3-1" | null;
 
 export type LiberalSystemType = "자유학년제" | "자유학기제";
 
+export type YesNo = "YES" | "NO";
+
 export interface MiddleSchoolAchievementType {
   achievement1_1: number[] | null;
   achievement1_2: number[] | null;
@@ -83,4 +85,20 @@ export interface GetMyOneseoType {
       generalSubjects: string[];
     };
   step: number | null;
+}
+
+export interface OneseoType {
+  memberId: number;
+  submitCode: string;
+  realOneseoArrivedYn: YesNo;
+  name: string;
+  screening: ScreeningType;
+  schoolName: string;
+  phoneNumber: string;
+  guardianPhoneNumber: string;
+  schoolTeacherPhoneNumber: string;
+  firstTestPassYn: YesNo;
+  aptitudeEvaluationScore: number;
+  interviewScore: number;
+  secondTestPassYn: YesNo;
 }


### PR DESCRIPTION
## 개요 💡

> admin의 메인 페이지를 조립 및, 구성했습니다.

## 작업내용 ⌨️

- 각 컴포넌트의 스타일을 전체 페이지 구성에 맞게 일부 변경했습니다.
<img width="1800" alt="image" src="https://github.com/user-attachments/assets/54fd6fa2-7267-4c4a-bbb2-fe8d684aa862">

// TODO
- API 스펙에 맞는 application 타입 선언과, 페이지네이션 구성이 필요합니다.


