### PR TITLE
[Member] 로그인 시 유저 정보가 없다면 회원가입으로 이동.

### DIFF
--- a/apps/client/src/app/apis/member/getMyAuthInfo.ts
+++ b/apps/client/src/app/apis/member/getMyAuthInfo.ts
@@ -1,3 +1,4 @@
+import { cookies } from 'next/headers';
 import { redirect } from 'next/navigation';
 
 import { memberUrl } from 'api/libs';
@@ -10,9 +11,19 @@ import type { MyAuthInfoType } from 'types';
  * @returns 나의 인증 정보를 반환합니다. 없다면 -> TODO 서버 문서 업데이트 중입니다.
  */
 export const getMyAuthInfo = async (redirectUrl: string): Promise<MyAuthInfoType | undefined> => {
-  const response = await fetch(new URL(`${memberUrl.getMyAuthInfo()}`, process.env.BASE_URL), {
-    method: 'GET',
-  });
+  const session = cookies().get('SESSION')?.value;
+
+  const response = await fetch(
+    new URL(memberUrl.getMyAuthInfo(), process.env.NEXT_PUBLIC_API_BASE_URL),
+    {
+      method: 'GET',
+      credentials: 'include',
+      headers: {
+        'Content-Type': 'application/json',
+        Cookie: `SESSION=${session}`,
+      },
+    },
+  );
 
   const authInfo = await response.json();
   const isUnauthorized = response.status === 401;
@@ -26,5 +37,5 @@ export const getMyAuthInfo = async (redirectUrl: string): Promise<MyAuthInfoType
     return redirect(redirectUrl);
   }
 
-  return authInfo;
+  return authInfo.data;
 };

--- a/apps/client/src/app/apis/member/getMyMemberInfo.ts
+++ b/apps/client/src/app/apis/member/getMyMemberInfo.ts
@@ -1,3 +1,4 @@
+import { cookies } from 'next/headers';
 import { redirect } from 'next/navigation';
 
 import { memberUrl } from 'api/libs';
@@ -12,9 +13,19 @@ import type { MyMemberInfoType } from 'types';
 export const getMyMemberInfo = async (
   redirectUrl: string,
 ): Promise<MyMemberInfoType | undefined> => {
-  const response = await fetch(new URL(`${memberUrl.getMyMemberInfo()}`, process.env.BASE_URL), {
-    method: 'GET',
-  });
+  const session = cookies().get('SESSION')?.value;
+
+  const response = await fetch(
+    new URL(memberUrl.getMyMemberInfo(), process.env.NEXT_PUBLIC_API_BASE_URL),
+    {
+      method: 'GET',
+      credentials: 'include',
+      headers: {
+        'Content-Type': 'application/json',
+        Cookie: `SESSION=${session}`,
+      },
+    },
+  );
 
   const memberInfo = await response.json();
   const isUnauthorized = response.status === 401;
@@ -28,5 +39,5 @@ export const getMyMemberInfo = async (
     return redirect(redirectUrl);
   }
 
-  return memberInfo;
+  return memberInfo.data;
 };

--- a/apps/client/src/app/page.tsx
+++ b/apps/client/src/app/page.tsx
@@ -1,5 +1,16 @@
+import { redirect } from 'next/navigation';
+
 import { MainPage } from 'client/pageContainer';
 
-export default function Home() {
+import { getMyAuthInfo, getMyMemberInfo } from './apis';
+
+export default async function Home() {
+  const memberInfo = await getMyMemberInfo('/');
+  const authInfo = await getMyAuthInfo('/');
+
+  if (authInfo?.authReferrerType && !memberInfo?.name) {
+    redirect('/signup');
+  }
+
   return <MainPage />;
 }

--- a/apps/client/src/components/Header/index.tsx
+++ b/apps/client/src/components/Header/index.tsx
@@ -76,10 +76,12 @@ const Header = () => {
         </ActiveLink>
       </nav>
 
-      {authInfo && memberInfo ? (
+      {authInfo?.authReferrerType && memberInfo?.name ? (
         <Link href="/" className={cn(...loginLinkStyle)}>
           <I.HeaderProfileIcon /> {memberInfo.name} 님
         </Link>
+      ) : authInfo?.authReferrerType && !memberInfo?.name ? (
+        '회원가입을 진행해주세요'
       ) : (
         <LoginDialog />
       )}


### PR DESCRIPTION
## 개요 💡

> 로그인 시 유저 정보가 업다면 회원가입으로 이동되도록 하였습니다.

## 작업내용 ⌨️

- 회원가입 페이지에도 헤더가 존재하여, 잘못된 유저 정보가 표시되었습니다. 이를 예외처리 했습니다.
