### PR TITLE
[QA] 회원가입시 refetch 추가, freeSemester null 로직을 변경

### DIFF
--- a/apps/client/src/pageContainer/PrintPage/index.tsx
+++ b/apps/client/src/pageContainer/PrintPage/index.tsx
@@ -6,6 +6,7 @@ import { plusAll } from 'shared';
 import { GetMyOneseoType, SexEnum } from 'types';
 
 import { OneseoStatus } from 'client/components';
+import { cn } from 'client/lib/utils';
 
 import { PrintIcon } from 'shared/assets';
 import { Button } from 'shared/components';
@@ -50,7 +51,7 @@ const ApplicationPage = ({ initialData }: PrintPageProps) => {
 
   const getArtPhysicalElement = (achievement: number[] | null) => {
     if (!achievement) {
-      return <div className="h-full bg-no-repeat bg-contain bg-slash"></div>;
+      return <div className="h-full bg-slash bg-contain bg-no-repeat"></div>;
     }
 
     const subjectLength = oneseo.middleSchoolAchievement.artsPhysicalSubjects.length;
@@ -96,14 +97,14 @@ const ApplicationPage = ({ initialData }: PrintPageProps) => {
       `}</style>
       {/* 입학원서 */}
       <Button
-        className="fixed items-center gap-2 bottom-10 right-24 print:hidden"
+        className="fixed bottom-10 right-24 items-center gap-2 print:hidden"
         onClick={handlePrint}
       >
         <PrintIcon />
         <p className="text-[2.1vh] font-bold hover:text-white">인쇄하기</p>
       </Button>
 
-      <div className="flex flex-col items-center h-fit justify-center overflow-hidden bg-white p-2 text-[1vh]">
+      <div className="flex h-fit flex-col items-center justify-center overflow-hidden bg-white p-2 text-[1vh]">
         <div className="relative z-[2] w-[63vh]">
           <div
             id="sample"
@@ -125,14 +126,14 @@ const ApplicationPage = ({ initialData }: PrintPageProps) => {
                   <th className="w-20 border border-b-0 border-black bg-[#e9e9e9] p-[0.2vh] align-middle font-medium">
                     접수번호
                   </th>
-                  <td className="w-40 text-center border border-b-0 border-black">
+                  <td className="w-40 border border-b-0 border-black text-center">
                     {oneseo.oneseoId}
                   </td>
                 </tr>
               </table>
             </div>
           </div>
-          <div className="border border-t-0 border-r-0 border-black">
+          <div className="border border-r-0 border-t-0 border-black">
             <table className="w-full border-collapse text-center text-[1.2vh]">
               <thead>
                 <tr>
@@ -150,15 +151,13 @@ const ApplicationPage = ({ initialData }: PrintPageProps) => {
                   <td className={tdStyle}>{SexEnum[oneseo.privacyDetail.sex ?? 'MALE']}</td>
                   <th className={thStyle}>생년월일</th>
                   <td className={tdStyle}>{oneseo.privacyDetail.birth}</td>
-                  <td
-                    rowSpan={6}
-                    className={tdStyle + 'h-[25vh] w-[18vh]'}
-                    style={{
-                      backgroundImage: `url(${oneseo.privacyDetail.profileImg})`,
-                      backgroundSize: '18vh 25vh',
-                      backgroundRepeat: 'no-repeat',
-                    }}
-                  ></td>
+                  <td rowSpan={6} className={tdStyle + 'h-[25vh] w-[18vh]'}>
+                    <img
+                      src={oneseo.privacyDetail.profileImg}
+                      alt="증명사진"
+                      className={cn('h-[25vh]', 'w-[18vh]')}
+                    />
+                  </td>
                 </tr>
                 <tr>
                   <th className={thStyle}>주 소</th>
@@ -221,29 +220,29 @@ const ApplicationPage = ({ initialData }: PrintPageProps) => {
               </thead>
             </table>
             <OneseoStatus oneseo={oneseo} />
-            <div className="p-2 text-sm border-r border-black">
+            <div className="border-r border-black p-2 text-sm">
               <div className="mb-4">
                 위 학생은 2024학년도 귀교 제1학년에 입학하고자 소정의 서류를 갖추어 지원하며, &nbsp;
                 <strong>다른 산업수요맞춤형(마이스터)고등학교에 이중지원하지 않을 것을 서약</strong>
                 합니다.
               </div>
-              <div className="flex justify-center mb-4">
+              <div className="mb-4 flex justify-center">
                 <p className="mr-6">년</p>
                 <p className="mr-6">월</p>
                 <p>일</p>
               </div>
-              <div className="flex justify-end w-full gap-20 mb-4">
+              <div className="mb-4 flex w-full justify-end gap-20">
                 <p>지원자 :</p>
                 <p className="text-end">(인)</p>
               </div>
-              <div className="flex justify-end w-full gap-20 mb-4">
+              <div className="mb-4 flex w-full justify-end gap-20">
                 <p>보호자 :</p>
                 <p className="text-end">(인)</p>
               </div>
-              <div className="text-left ">광주소프트웨어마이스터고등학교장 귀하</div>
-              <div className="w-full h-[0.5px] bg-slate-400"></div>
-              <div className="text-center ">위 기재 사항이 사실과 같음을 확인합니다.</div>
-              <div className="text-base text-right ">중학교장[직인]</div>
+              <div className="text-left">광주소프트웨어마이스터고등학교장 귀하</div>
+              <div className="h-[0.5px] w-full bg-slate-400"></div>
+              <div className="text-center">위 기재 사항이 사실과 같음을 확인합니다.</div>
+              <div className="text-right text-base">중학교장[직인]</div>
             </div>
           </div>
           <div className="my-4 text-center">2차 전형 응시 준비물 : 신분증[학생증], 필기구 등</div>
@@ -254,27 +253,27 @@ const ApplicationPage = ({ initialData }: PrintPageProps) => {
 
         {!isGEDScore && (
           <div className="relative z-[2] w-[66vh] overflow-hidden">
-            <div className="relative p-4 text-black bg-white">
-              <div className="relative z-[2] p-6 bg-white border border-gray-300 shadow-md">
+            <div className="relative bg-white p-4 text-black">
+              <div className="relative z-[2] border border-gray-300 bg-white p-6 shadow-md">
                 <div
                   id="sample"
-                  className="absolute top-[-60px] z-[-2] text-[40vh] text-gray-200 transform rotate-[-30deg] text-center select-none"
+                  className="absolute top-[-60px] z-[-2] rotate-[-30deg] transform select-none text-center text-[40vh] text-gray-200"
                 >
                   견본
                 </div>
                 <p>[서식 3]</p>
-                <h1 className="text-[1.8vh] font-bold text-center">
+                <h1 className="text-center text-[1.8vh] font-bold">
                   {targetDate}학년도 광주소프트웨어마이스터고등학교 입학 전형성적 입력 확인서
                 </h1>
                 <div className="flex items-end justify-between">
-                  <h2 className="text-[1.2vh] mt-[1.5vh] leading-[2vh]">일반교과</h2>
+                  <h2 className="mt-[1.5vh] text-[1.2vh] leading-[2vh]">일반교과</h2>
                   <div>
                     <table>
                       <tr>
                         <th className="w-20 border border-b-0 border-black bg-[#e9e9e9] p-[0.2vh] align-middle font-medium">
                           접수번호
                         </th>
-                        <td className="w-40 text-center border border-b-0 border-black">
+                        <td className="w-40 border border-b-0 border-black text-center">
                           {oneseo.oneseoId}
                         </td>
                       </tr>
@@ -282,11 +281,11 @@ const ApplicationPage = ({ initialData }: PrintPageProps) => {
                   </div>
                 </div>
 
-                <div className="flex border border-black h-fit">
-                  <div className="flex flex-col w-full border-r border-black">
+                <div className="flex h-fit border border-black">
+                  <div className="flex w-full flex-col border-r border-black">
                     <div className="relative z-10 border-b border-black bg-backslash">
-                      <div className="text-right h-[2.2vh]">학년</div>
-                      <div className="text-left h-[2.2vh]">과목</div>
+                      <div className="h-[2.2vh] text-right">학년</div>
+                      <div className="h-[2.2vh] text-left">과목</div>
                     </div>
                     {[
                       ...defaultSubjectArray,
@@ -301,17 +300,17 @@ const ApplicationPage = ({ initialData }: PrintPageProps) => {
                     ))}
                     <div className="flex items-center justify-center">환산점</div>
                   </div>
-                  <div className="flex flex-col w-full border-b-0 border-r border-black">
-                    <div className="flex flex-col ">
-                      <div className="font-bold bg-gray-200 border-b border-black text-center p-[0.2vh] h-[2.2vh]">
+                  <div className="flex w-full flex-col border-b-0 border-r border-black">
+                    <div className="flex flex-col">
+                      <div className="h-[2.2vh] border-b border-black bg-gray-200 p-[0.2vh] text-center font-bold">
                         1학년 1학기
                       </div>
-                      <div className="font-bold bg-gray-200 border-b border-black text-center p-[0.2vh] h-[2.2vh]">
+                      <div className="h-[2.2vh] border-b border-black bg-gray-200 p-[0.2vh] text-center font-bold">
                         성취도/평어
                       </div>
                     </div>
                     {!oneseo.middleSchoolAchievement.achievement1_1 ? (
-                      <div className="h-full bg-no-repeat bg-contain bg-slash"></div>
+                      <div className="h-full bg-slash bg-contain bg-no-repeat"></div>
                     ) : (
                       <>
                         {oneseo.middleSchoolAchievement.achievement1_1.map((score, i) => (
@@ -328,17 +327,17 @@ const ApplicationPage = ({ initialData }: PrintPageProps) => {
                       </>
                     )}
                   </div>
-                  <div className="flex flex-col w-full border-r border-black">
+                  <div className="flex w-full flex-col border-r border-black">
                     <div className="flex flex-col">
-                      <div className="font-bold bg-gray-200 border-b border-black text-center p-[0.2vh] h-[2.2vh]">
+                      <div className="h-[2.2vh] border-b border-black bg-gray-200 p-[0.2vh] text-center font-bold">
                         1학년 2학기
                       </div>
-                      <div className="font-bold bg-gray-200 border-b border-black text-center p-[0.2vh] h-[2.2vh]">
+                      <div className="h-[2.2vh] border-b border-black bg-gray-200 p-[0.2vh] text-center font-bold">
                         성취도/평어
                       </div>
                     </div>
                     {!oneseo.middleSchoolAchievement.achievement1_2 ? (
-                      <div className="h-full bg-no-repeat bg-contain bg-slash"></div>
+                      <div className="h-full bg-slash bg-contain bg-no-repeat"></div>
                     ) : (
                       <>
                         {oneseo.middleSchoolAchievement.achievement1_2.map((score, i) => (
@@ -355,17 +354,17 @@ const ApplicationPage = ({ initialData }: PrintPageProps) => {
                       </>
                     )}
                   </div>
-                  <div className="flex flex-col w-full border-r border-black">
+                  <div className="flex w-full flex-col border-r border-black">
                     <div className="flex flex-col">
-                      <div className="font-bold bg-gray-200 border-b border-black text-center p-[0.2vh] h-[2.2vh]">
+                      <div className="h-[2.2vh] border-b border-black bg-gray-200 p-[0.2vh] text-center font-bold">
                         2학년 1학기
                       </div>
-                      <div className="font-bold bg-gray-200 border-b border-black text-center p-[0.2vh] h-[2.2vh]">
+                      <div className="h-[2.2vh] border-b border-black bg-gray-200 p-[0.2vh] text-center font-bold">
                         성취도/평어
                       </div>
                     </div>
                     {!oneseo.middleSchoolAchievement.achievement2_1 ? (
-                      <div className="h-full bg-no-repeat bg-contain bg-slash"></div>
+                      <div className="h-full bg-slash bg-contain bg-no-repeat"></div>
                     ) : (
                       <>
                         {oneseo.middleSchoolAchievement.achievement2_1.map((score, i) => (
@@ -382,17 +381,17 @@ const ApplicationPage = ({ initialData }: PrintPageProps) => {
                       </>
                     )}
                   </div>
-                  <div className="flex flex-col w-full border-r border-black">
+                  <div className="flex w-full flex-col border-r border-black">
                     <div className="flex flex-col">
-                      <div className="font-bold bg-gray-200 border-b border-black text-center p-[0.2vh] h-[2.2vh]">
+                      <div className="h-[2.2vh] border-b border-black bg-gray-200 p-[0.2vh] text-center font-bold">
                         2학년 2학기
                       </div>
-                      <div className="font-bold bg-gray-200 border-b border-black text-center p-[0.2vh] h-[2.2vh]">
+                      <div className="h-[2.2vh] border-b border-black bg-gray-200 p-[0.2vh] text-center font-bold">
                         성취도/평어
                       </div>
                     </div>
                     {!oneseo.middleSchoolAchievement.achievement2_2 ? (
-                      <div className="h-full bg-no-repeat bg-contain bg-slash"></div>
+                      <div className="h-full bg-slash bg-contain bg-no-repeat"></div>
                     ) : (
                       <>
                         {oneseo.middleSchoolAchievement.achievement2_2.map((score, i) => (
@@ -409,17 +408,17 @@ const ApplicationPage = ({ initialData }: PrintPageProps) => {
                       </>
                     )}
                   </div>
-                  <div className="flex flex-col w-full border-black">
+                  <div className="flex w-full flex-col border-black">
                     <div className="flex flex-col">
-                      <div className="font-bold bg-gray-200 border-b border-black text-center p-[0.2vh] h-[2.2vh]">
+                      <div className="h-[2.2vh] border-b border-black bg-gray-200 p-[0.2vh] text-center font-bold">
                         3학년 1학기
                       </div>
-                      <div className="font-bold bg-gray-200 border-b border-black text-center p-[0.2vh] h-[2.2vh]">
+                      <div className="h-[2.2vh] border-b border-black bg-gray-200 p-[0.2vh] text-center font-bold">
                         성취도/평어
                       </div>
                     </div>
                     {!oneseo.middleSchoolAchievement.achievement3_1 ? (
-                      <div className="h-full bg-no-repeat bg-contain bg-slash"></div>
+                      <div className="h-full bg-slash bg-contain bg-no-repeat"></div>
                     ) : (
                       <>
                         {oneseo.middleSchoolAchievement.achievement3_1.map((score, i) => (
@@ -437,12 +436,12 @@ const ApplicationPage = ({ initialData }: PrintPageProps) => {
                     )}
                   </div>
                 </div>
-                <h2 className="text-[1.2vh] mt-[1.5vh] leading-[2vh]">체육예술교과</h2>
-                <div className="flex border border-black h-fit">
-                  <div className="flex flex-col w-full border-r border-black">
+                <h2 className="mt-[1.5vh] text-[1.2vh] leading-[2vh]">체육예술교과</h2>
+                <div className="flex h-fit border border-black">
+                  <div className="flex w-full flex-col border-r border-black">
                     <div className="relative z-10 border-b border-black bg-backslash">
-                      <div className="text-right h-[2.2vh]">학년</div>
-                      <div className="text-left h-[2.2vh]">과목</div>
+                      <div className="h-[2.2vh] text-right">학년</div>
+                      <div className="h-[2.2vh] text-left">과목</div>
                     </div>
                     {[...artPhysicalSubjectArray].map((subject) => (
                       <div
@@ -454,80 +453,80 @@ const ApplicationPage = ({ initialData }: PrintPageProps) => {
                     ))}
                     <div className="flex items-center justify-center">환산점</div>
                   </div>
-                  <div className="flex flex-col w-full border-b-0 border-r border-black">
-                    <div className="flex flex-col ">
-                      <div className="font-bold bg-gray-200 border-b border-black text-center p-[0.2vh] h-[2.2vh]">
+                  <div className="flex w-full flex-col border-b-0 border-r border-black">
+                    <div className="flex flex-col">
+                      <div className="h-[2.2vh] border-b border-black bg-gray-200 p-[0.2vh] text-center font-bold">
                         1학년 1학기
                       </div>
-                      <div className="font-bold bg-gray-200 border-b border-black text-center p-[0.2vh] h-[2.2vh]">
+                      <div className="h-[2.2vh] border-b border-black bg-gray-200 p-[0.2vh] text-center font-bold">
                         성취도/평어
                       </div>
                     </div>
                     {getArtPhysicalElement(oneseo.middleSchoolAchievement.achievement1_1)}
                   </div>
-                  <div className="flex flex-col w-full border-r border-black">
+                  <div className="flex w-full flex-col border-r border-black">
                     <div className="flex flex-col">
-                      <div className="font-bold bg-gray-200 border-b border-black text-center p-[0.2vh] h-[2.2vh]">
+                      <div className="h-[2.2vh] border-b border-black bg-gray-200 p-[0.2vh] text-center font-bold">
                         1학년 2학기
                       </div>
-                      <div className="font-bold bg-gray-200 border-b border-black text-center p-[0.2vh] h-[2.2vh]">
+                      <div className="h-[2.2vh] border-b border-black bg-gray-200 p-[0.2vh] text-center font-bold">
                         성취도/평어
                       </div>
                     </div>
                     {getArtPhysicalElement(oneseo.middleSchoolAchievement.achievement1_2)}
                   </div>
-                  <div className="flex flex-col w-full border-r border-black">
+                  <div className="flex w-full flex-col border-r border-black">
                     <div className="flex flex-col">
-                      <div className="font-bold bg-gray-200 border-b border-black text-center p-[0.2vh] h-[2.2vh]">
+                      <div className="h-[2.2vh] border-b border-black bg-gray-200 p-[0.2vh] text-center font-bold">
                         2학년 1학기
                       </div>
-                      <div className="font-bold bg-gray-200 border-b border-black text-center p-[0.2vh] h-[2.2vh]">
+                      <div className="h-[2.2vh] border-b border-black bg-gray-200 p-[0.2vh] text-center font-bold">
                         성취도/평어
                       </div>
                     </div>
                     {getArtPhysicalElement(oneseo.middleSchoolAchievement.achievement2_1)}
                   </div>
-                  <div className="flex flex-col w-full border-r border-black">
+                  <div className="flex w-full flex-col border-r border-black">
                     <div className="flex flex-col">
-                      <div className="font-bold bg-gray-200 border-b border-black text-center p-[0.2vh] h-[2.2vh]">
+                      <div className="h-[2.2vh] border-b border-black bg-gray-200 p-[0.2vh] text-center font-bold">
                         2학년 2학기
                       </div>
-                      <div className="font-bold bg-gray-200 border-b border-black text-center p-[0.2vh] h-[2.2vh]">
+                      <div className="h-[2.2vh] border-b border-black bg-gray-200 p-[0.2vh] text-center font-bold">
                         성취도/평어
                       </div>
                     </div>
                     {getArtPhysicalElement(oneseo.middleSchoolAchievement.achievement2_2)}
                   </div>
-                  <div className="flex flex-col w-full border-black">
+                  <div className="flex w-full flex-col border-black">
                     <div className="flex flex-col">
-                      <div className="font-bold bg-gray-200 border-b border-black text-center p-[0.2vh] h-[2.2vh]">
+                      <div className="h-[2.2vh] border-b border-black bg-gray-200 p-[0.2vh] text-center font-bold">
                         3학년 1학기
                       </div>
-                      <div className="font-bold bg-gray-200 border-b border-black text-center p-[0.2vh] h-[2.2vh]">
+                      <div className="h-[2.2vh] border-b border-black bg-gray-200 p-[0.2vh] text-center font-bold">
                         성취도/평어
                       </div>
                     </div>
                     {getArtPhysicalElement(oneseo.middleSchoolAchievement.achievement3_1)}
                   </div>
                 </div>
-                <h2 className="text-[1.2vh] mt-[1.5vh] leading-[2vh]">비교과</h2>
+                <h2 className="mt-[1.5vh] text-[1.2vh] leading-[2vh]">비교과</h2>
                 <table className="w-full border-collapse border text-[1vh]">
                   <thead>
                     <tr>
                       <th
-                        className="border border-black p-[0.3vh] font-bold bg-gray-200"
+                        className="border border-black bg-gray-200 p-[0.3vh] font-bold"
                         rowSpan={2}
                       >
                         학년
                       </th>
                       <th
-                        className="border border-black p-[0.3vh] font-bold bg-gray-200"
+                        className="border border-black bg-gray-200 p-[0.3vh] font-bold"
                         colSpan={6}
                       >
                         미인정 출결 현황
                       </th>
                       <th
-                        className="border border-black p-[0.3vh] font-bold bg-gray-200"
+                        className="border border-black bg-gray-200 p-[0.3vh] font-bold"
                         colSpan={2}
                       >
                         봉사활동
@@ -608,11 +607,11 @@ const ApplicationPage = ({ initialData }: PrintPageProps) => {
                     </tr>
                   </tbody>
                 </table>
-                <table className="mx-auto w-[80%] border-collapse border text-[1vh] mt-[1.5vh]">
+                <table className="mx-auto mt-[1.5vh] w-[80%] border-collapse border text-[1vh]">
                   <thead>
                     <tr>
                       <th
-                        className="border border-black p-[0.3vh] font-bold bg-gray-200"
+                        className="border border-black bg-gray-200 p-[0.3vh] font-bold"
                         colSpan={4}
                       >
                         입력자 확인
@@ -621,43 +620,43 @@ const ApplicationPage = ({ initialData }: PrintPageProps) => {
                   </thead>
                   <tbody>
                     <tr>
-                      <th className="border border-black p-[0.3vh] font-bold bg-gray-200">
+                      <th className="border border-black bg-gray-200 p-[0.3vh] font-bold">
                         담임교사
                       </th>
                       <td className="border border-black p-[0.3vh] text-right">(인)</td>
-                      <th className="border border-black p-[0.3vh] font-bold bg-gray-200">
+                      <th className="border border-black bg-gray-200 p-[0.3vh] font-bold">
                         지원자
                       </th>
                       <td className="border border-black p-[0.3vh] text-right">(인)</td>
                     </tr>
                   </tbody>
                 </table>
-                <table className="mx-auto w-[50%] border-collapse border text-[1vh] mt-[1.5vh]">
+                <table className="mx-auto mt-[1.5vh] w-[50%] border-collapse border text-[1vh]">
                   <thead>
                     <tr>
                       <th
-                        className="border border-black p-[0.3vh] font-bold bg-gray-200"
+                        className="border border-black bg-gray-200 p-[0.3vh] font-bold"
                         rowSpan={2}
                       >
                         접수자 확인
                       </th>
-                      <th className="border border-black p-[0.3vh] font-bold bg-gray-200">1차</th>
+                      <th className="border border-black bg-gray-200 p-[0.3vh] font-bold">1차</th>
                       <td className="border border-black p-[0.3vh] text-right">(인)</td>
                     </tr>
                     <tr>
-                      <th className="border border-black p-[0.3vh] font-bold bg-gray-200">2차</th>
+                      <th className="border border-black bg-gray-200 p-[0.3vh] font-bold">2차</th>
                       <td className="border border-black p-[0.3vh] text-right">(인)</td>
                     </tr>
                   </thead>
                 </table>
-                <div className="text-center text-[1.2vh] mt-[2vh]">
+                <div className="mt-[2vh] text-center text-[1.2vh]">
                   <p>위와 같이 입력하고 확인하였음을 증명합니다.</p>
-                  <div className="flex justify-center mb-4">
+                  <div className="mb-4 flex justify-center">
                     <p className="mr-6">년</p>
                     <p className="mr-6">월</p>
                     <p>일</p>
                   </div>
-                  <div className="flex justify-between text-[1vh] mt-[1vh]  text-sm">
+                  <div className="mt-[1vh] flex justify-between text-[1vh] text-sm">
                     <span>광주소프트웨어마이스터고등학교장 귀하</span>
                     <span>중학교장[직인]</span>
                   </div>

--- a/packages/shared/src/components/ScoreRegister/index.tsx
+++ b/packages/shared/src/components/ScoreRegister/index.tsx
@@ -430,11 +430,7 @@ const ScoreRegister = ({
     if (subjectArray.length <= defaultSubjectLength) {
       setValue('newSubjects', null);
     }
-
-    // if (liberalSystem === 'freeGrade' && freeSemester) {
-    //   setValue(freeSemester, null);
-    // }
-  }, [defaultSubjectLength, freeSemester, setValue, subjectArray]);
+  }, [defaultSubjectLength, freeSemester, liberalSystem, setValue, subjectArray]);
 
   return (
     <>
@@ -493,6 +489,10 @@ const ScoreRegister = ({
                 if (liberalSystem === 'freeGrade') {
                   setValue('achievement1_1', null);
                   setValue('achievement1_2', null);
+                }
+
+                if (liberalSystem === 'freeSemester' && freeSemester) {
+                  setValue(freeSemester, null);
                 }
 
                 handleSubmit(handleFormSubmit)();


### PR DESCRIPTION
## 개요 💡

회원가입시 refetch 추가, freeSemester null 로직을 변경하였습니다

## 작업내용 ⌨️

- 회원가입 성공시 refetch를 실행해 회원 정보를 다시 가져옵니다
- freeSemester null 로직을 변경해 다른 학기를 on 할시 전 학기의 placeholder가 제대로 보입니다
- `/print` tr background-image -> img src로 변경