### PR TITLE
[Feat] 서버 의존성 제거 

### DIFF
--- a/apps/client/src/app/apis/oneseo/getMyOneseo.ts
+++ b/apps/client/src/app/apis/oneseo/getMyOneseo.ts
@@ -5,22 +5,23 @@ import { oneseoUrl } from 'api/libs';
 
 export const getMyOneseo = async (): Promise<GetMyOneseoType | undefined> => {
   const session = cookies().get('SESSION')?.value;
-
-  const response = await fetch(
-    new URL(oneseoUrl.getMyOneseo(), process.env.NEXT_PUBLIC_API_BASE_URL),
-    {
-      method: 'GET',
-      credentials: 'include',
-      headers: {
-        'Content-Type': 'application/json',
-        Cookie: `SESSION=${session}`,
+  try {
+    const response = await fetch(
+      new URL(oneseoUrl.getMyOneseo(), process.env.NEXT_PUBLIC_API_BASE_URL),
+      {
+        method: 'GET',
+        credentials: 'include',
+        headers: {
+          'Content-Type': 'application/json',
+          Cookie: `SESSION=${session}`,
+        },
       },
-    },
-  );
+    );
 
-  const myOneseo = await response.json();
+    const myOneseo = await response.json();
 
-  if (response.status === 404) return undefined;
-
-  return myOneseo.data;
+    return myOneseo.data;
+  } catch {
+    return undefined;
+  }
 };

--- a/apps/client/src/app/check-result/layout.tsx
+++ b/apps/client/src/app/check-result/layout.tsx
@@ -45,15 +45,7 @@ const Layout = ({
       <AlertDialog open={!authInfo?.authReferrerType || !memberInfo?.name}>
         <AlertDialogContent className="w-[400px]">
           <AlertDialogHeader>
-            <AlertDialogTitle>
-              <strong>로그인을 먼저 진행해주세요</strong>
-              <br />
-              <br />
-              학부모/ 담임교사 합격확인 시, 보안상의 문제로 본인확인을 위해 회원가입 후 학부모/
-              담임교사의 본인 로그인이 필요합니다. <br />
-              <br /> 빠른 확인을 원하시는 경우, 062-949-6842로 전화주시면 친절히 안내드리겠습니다.{' '}
-              <br /> 번거롭게 해드려 죄송합니다.
-            </AlertDialogTitle>
+            <AlertDialogTitle>로그인을 먼저 진행해주세요</AlertDialogTitle>
           </AlertDialogHeader>
           <AlertDialogFooter>
             <LoginDialog />

--- a/apps/client/src/pageContainer/MainPage/index.tsx
+++ b/apps/client/src/pageContainer/MainPage/index.tsx
@@ -2,13 +2,11 @@
 
 import { useEffect, useState } from 'react';
 
-import { useGetMyAuthInfo } from 'api';
-import Link from 'next/link';
+// import { useGetMyAuthInfo } from 'api';
 import { MyMemberInfoType, MyTotalTestResultType } from 'types';
 
 import {
   Footer,
-  LoginDialog,
   PassResultDialog,
   Section1,
   Section2,
@@ -18,18 +16,7 @@ import {
   TestResultDialog,
 } from 'client/components';
 
-import {
-  AlertDialog,
-  AlertDialogAction,
-  AlertDialogContent,
-  AlertDialogFooter,
-  AlertDialogHeader,
-  AlertDialogTitle,
-  Dialog,
-  DialogContent,
-  DialogHeader,
-  DialogTitle,
-} from 'shared/components';
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from 'shared/components';
 import { cn } from 'shared/lib/utils';
 
 interface MainPageProps {
@@ -54,7 +41,7 @@ const MainPage = ({ memberInfo, resultInfo }: MainPageProps) => {
       setIsOpen(false);
     }
   }, []);
-  const [isClicked, setIsClicked] = useState(false);
+  // const [isClicked, setIsClicked] = useState(false);
 
   useEffect(() => {
     if (process.env.NEXT_PUBLIC_STAGE === 'stage') {
@@ -64,10 +51,10 @@ const MainPage = ({ memberInfo, resultInfo }: MainPageProps) => {
 
   const isFinishFirstTest = resultInfo?.secondTestPassYn === null ? true : false;
 
-  const { data: authInfo } = useGetMyAuthInfo();
+  // const { data: authInfo } = useGetMyAuthInfo();
   return (
     <>
-      <AlertDialog open={!isClicked && (!authInfo?.authReferrerType || !memberInfo?.name)}>
+      {/* <AlertDialog open={!isClicked && (!authInfo?.authReferrerType || !memberInfo?.name)}>
         <AlertDialogContent className="w-[400px]">
           <AlertDialogHeader>
             <AlertDialogTitle>
@@ -89,7 +76,7 @@ const MainPage = ({ memberInfo, resultInfo }: MainPageProps) => {
             </AlertDialogAction>
           </AlertDialogFooter>
         </AlertDialogContent>
-      </AlertDialog>
+      </AlertDialog> */}
       <Section1 />
       <Section2 />
       <Section3 />


### PR DESCRIPTION
## 개요 💡

서버의 상태가 상용중이 아닐때도 프론트에서 문제없이 볼수 있도록 수정했습니다

> 서버 의존성 제거 전
![Screenshot 2024-11-21 at 5 09 36 PM](https://github.com/user-attachments/assets/92ed0f65-6aa9-448f-a868-80e6cbea7f78)
> 서버 의존성 제거 후
![Screenshot 2024-11-21 at 5 09 58 PM](https://github.com/user-attachments/assets/88ff0ed7-75fc-43b0-bbf4-dc1b4452e6f9)

## 작업내용 ⌨️

- getMyOneseo 함수에서 response의 status로 error를 확인하는 방식에서 try catch로 확인하는 방식으로 변경
- 임시 합격 안내 모달을 기존 안내 모달로 변경