### PR TITLE
[fix]: 로그인 방법 바로가기 버튼 클릭 시 드롭다운 활성화

### DIFF
--- a/apps/client/src/app/faq/page.tsx
+++ b/apps/client/src/app/faq/page.tsx
@@ -1,5 +1,7 @@
 import { FaqPage } from 'client/pageContainer';
 
-export default function Guide() {
-  return <FaqPage />;
+export default function Guide({ searchParams }: { searchParams: { openIndex?: string } }) {
+  return (
+    <FaqPage openIndex={searchParams.openIndex ? Number(searchParams.openIndex) : undefined} />
+  );
 }

--- a/apps/client/src/app/faq/page.tsx
+++ b/apps/client/src/app/faq/page.tsx
@@ -1,6 +1,6 @@
 import { FaqPage } from 'client/pageContainer';
 
-export default function Guide({ searchParams }: { searchParams: { openIndex?: string } }) {
+export default function Faq({ searchParams }: { searchParams: { openIndex?: string } }) {
   return (
     <FaqPage openIndex={searchParams.openIndex ? Number(searchParams.openIndex) : undefined} />
   );

--- a/apps/client/src/app/faq/page.tsx
+++ b/apps/client/src/app/faq/page.tsx
@@ -1,7 +1,7 @@
 import { FaqPage } from 'client/pageContainer';
 
-export default function Faq({ searchParams }: { searchParams: { openIndex?: string } }) {
+export default function Faq({ searchParams: {openIndex} }: { searchParams: { openIndex?: string } }) {
   return (
-    <FaqPage openIndex={searchParams.openIndex ? Number(searchParams.openIndex) : undefined} />
+    <FaqPage openIndex={openIndex ? Number(openIndex) : undefined} />
   );
 }

--- a/apps/client/src/components/MainPage/Section3/index.tsx
+++ b/apps/client/src/components/MainPage/Section3/index.tsx
@@ -166,7 +166,7 @@ const Section3 = ({ isServerHealthy }: Section3Props) => {
                   여러 계정으로 로그인 하는 방법을 알려드릴게요!
                 </p>
               </div>
-              <Link href="/faq?dropdown=open" className={cn(...buttonStyle, 'self-end')}>
+              <Link href="/faq?openIndex=0" className={cn(...buttonStyle, 'self-end')}>
                 바로가기
               </Link>
             </div>

--- a/apps/client/src/components/MainPage/Section3/index.tsx
+++ b/apps/client/src/components/MainPage/Section3/index.tsx
@@ -166,7 +166,7 @@ const Section3 = ({ isServerHealthy }: Section3Props) => {
                   여러 계정으로 로그인 하는 방법을 알려드릴게요!
                 </p>
               </div>
-              <Link href="/faq" className={cn(...buttonStyle, 'self-end')}>
+              <Link href="/faq?dropdown=open" className={cn(...buttonStyle, 'self-end')}>
                 바로가기
               </Link>
             </div>

--- a/apps/client/src/pageContainer/FaqPage/index.tsx
+++ b/apps/client/src/pageContainer/FaqPage/index.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useEffect } from 'react';
+import { useState, useEffect, Suspense } from 'react';
 
 import { useSearchParams, useRouter, usePathname } from 'next/navigation';
 
@@ -21,7 +21,7 @@ import { Element } from './exampleElement';
 
 const ITEMS_PER_PAGE = 10;
 
-const FaqPage = () => {
+const FaqPageComponent = () => {
   const [currentPage, setCurrentPage] = useState<number>(1);
   const [keyword, setKeyword] = useState<string>('');
   const [faqStates, setFaqStates] = useState<{ [key: number]: boolean }>({});
@@ -167,6 +167,14 @@ const FaqPage = () => {
       </div>
       <Footer />
     </div>
+  );
+};
+
+const FaqPage = () => {
+  return (
+    <Suspense>
+      <FaqPageComponent />
+    </Suspense>
   );
 };
 

--- a/apps/client/src/pageContainer/FaqPage/index.tsx
+++ b/apps/client/src/pageContainer/FaqPage/index.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useEffect } from 'react';
+import { useState, useEffect, Suspense } from 'react';
 
 import { useSearchParams } from 'next/navigation';
 
@@ -21,7 +21,7 @@ import { Element } from './exampleElement';
 
 const ITEMS_PER_PAGE = 10;
 
-const FaqPage = () => {
+const FaqPageComponent = () => {
   const [currentPage, setCurrentPage] = useState<number>(1);
   const [keyword, setKeyword] = useState<string>('');
   const [faqStates, setFaqStates] = useState<{ [key: number]: boolean }>({});
@@ -155,6 +155,14 @@ const FaqPage = () => {
       </div>
       <Footer />
     </div>
+  );
+};
+
+const FaqPage = () => {
+  return (
+    <Suspense>
+      <FaqPageComponent />
+    </Suspense>
   );
 };
 

--- a/apps/client/src/pageContainer/FaqPage/index.tsx
+++ b/apps/client/src/pageContainer/FaqPage/index.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useEffect, Suspense } from 'react';
 
-import { useSearchParams } from 'next/navigation';
+import { useSearchParams, useRouter, usePathname } from 'next/navigation';
 
 import { FaqElement, Footer } from 'client/components';
 
@@ -28,15 +28,17 @@ const FaqPageComponent = () => {
   const [isPageChanging, setIsPageChanging] = useState<boolean>(false);
 
   const searchParams = useSearchParams();
+  const router = useRouter();
+  const pathname = usePathname();
+
+  const totalItems = Element.filter((item) => item.title.toLowerCase().includes(keyword));
+  const totalPages = Math.ceil(totalItems.length / ITEMS_PER_PAGE);
 
   useEffect(() => {
     if (searchParams.get('dropdown') === 'open' && Element.length > 0) {
       setFaqStates({ 0: true });
     }
   }, [searchParams]);
-
-  const totalItems = Element.filter((item) => item.title.toLowerCase().includes(keyword));
-  const totalPages = Math.ceil(totalItems.length / ITEMS_PER_PAGE);
 
   const handlePageChange = (pageNumber: number) => {
     const newPageNumber = Math.max(1, Math.min(pageNumber, totalPages));
@@ -58,10 +60,18 @@ const FaqPageComponent = () => {
   );
 
   const toggleFaqContent = (index: number) => {
-    setFaqStates((prevStates) => ({
-      ...prevStates,
-      [index]: !prevStates[index],
-    }));
+    setFaqStates((prevStates) => {
+      const newFaqStates = {
+        ...prevStates,
+        [index]: !prevStates[index],
+      };
+      if (!newFaqStates[index]) {
+        const newSearchParams = new URLSearchParams(searchParams.toString());
+        newSearchParams.delete('dropdown');
+        router.replace(`${pathname}?${newSearchParams.toString()}`);
+      }
+      return newFaqStates;
+    });
   };
 
   return (

--- a/apps/client/src/pageContainer/FaqPage/index.tsx
+++ b/apps/client/src/pageContainer/FaqPage/index.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useEffect, Suspense } from 'react';
+import { useState, useEffect } from 'react';
 
 import { useSearchParams, useRouter, usePathname } from 'next/navigation';
 
@@ -21,7 +21,7 @@ import { Element } from './exampleElement';
 
 const ITEMS_PER_PAGE = 10;
 
-const FaqPageComponent = () => {
+const FaqPage = () => {
   const [currentPage, setCurrentPage] = useState<number>(1);
   const [keyword, setKeyword] = useState<string>('');
   const [faqStates, setFaqStates] = useState<{ [key: number]: boolean }>({});
@@ -35,8 +35,9 @@ const FaqPageComponent = () => {
   const totalPages = Math.ceil(totalItems.length / ITEMS_PER_PAGE);
 
   useEffect(() => {
-    if (searchParams.get('openIndex') === '0' && Element.length > 0) {
-      setFaqStates({ 0: true });
+    const openIndex = searchParams.get('openIndex');
+    if (openIndex && !isNaN(Number(openIndex))) {
+      setFaqStates({ [Number(openIndex)]: true });
     }
   }, [searchParams]);
 
@@ -61,15 +62,16 @@ const FaqPageComponent = () => {
 
   const toggleFaqContent = (index: number) => {
     setFaqStates((prevStates) => {
-      const newFaqStates = {
-        ...prevStates,
-        [index]: !prevStates[index],
-      };
-      if (!newFaqStates[index]) {
-        const newSearchParams = new URLSearchParams(searchParams.toString());
+      const isOpen = !prevStates[index];
+      const newFaqStates = { [index]: isOpen };
+
+      const newSearchParams = new URLSearchParams(searchParams.toString());
+      if (isOpen) {
+        newSearchParams.set('openIndex', String(index));
+      } else {
         newSearchParams.delete('openIndex');
-        router.replace(`${pathname}?${newSearchParams.toString()}`);
       }
+      router.replace(`${pathname}?${newSearchParams.toString()}`);
       return newFaqStates;
     });
   };
@@ -165,14 +167,6 @@ const FaqPageComponent = () => {
       </div>
       <Footer />
     </div>
-  );
-};
-
-const FaqPage = () => {
-  return (
-    <Suspense>
-      <FaqPageComponent />
-    </Suspense>
   );
 };
 

--- a/apps/client/src/pageContainer/FaqPage/index.tsx
+++ b/apps/client/src/pageContainer/FaqPage/index.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useEffect, Suspense } from 'react';
+import { useState } from 'react';
 
 import { useSearchParams, useRouter, usePathname } from 'next/navigation';
 
@@ -21,10 +21,12 @@ import { Element } from './exampleElement';
 
 const ITEMS_PER_PAGE = 10;
 
-const FaqPageComponent = () => {
+const FaqPage = ({ openIndex }: { openIndex?: number }) => {
   const [currentPage, setCurrentPage] = useState<number>(1);
   const [keyword, setKeyword] = useState<string>('');
-  const [faqStates, setFaqStates] = useState<{ [key: number]: boolean }>({});
+  const [faqStates, setFaqStates] = useState<{ [key: number]: boolean }>(
+    openIndex !== undefined ? { [openIndex]: true } : {},
+  );
   const [isPageChanging, setIsPageChanging] = useState<boolean>(false);
 
   const searchParams = useSearchParams();
@@ -33,13 +35,6 @@ const FaqPageComponent = () => {
 
   const totalItems = Element.filter((item) => item.title.toLowerCase().includes(keyword));
   const totalPages = Math.ceil(totalItems.length / ITEMS_PER_PAGE);
-
-  useEffect(() => {
-    const openIndex = searchParams.get('openIndex');
-    if (openIndex && !isNaN(Number(openIndex))) {
-      setFaqStates({ [Number(openIndex)]: true });
-    }
-  }, [searchParams]);
 
   const handlePageChange = (pageNumber: number) => {
     const newPageNumber = Math.max(1, Math.min(pageNumber, totalPages));
@@ -167,14 +162,6 @@ const FaqPageComponent = () => {
       </div>
       <Footer />
     </div>
-  );
-};
-
-const FaqPage = () => {
-  return (
-    <Suspense>
-      <FaqPageComponent />
-    </Suspense>
   );
 };
 

--- a/apps/client/src/pageContainer/FaqPage/index.tsx
+++ b/apps/client/src/pageContainer/FaqPage/index.tsx
@@ -1,6 +1,8 @@
 'use client';
 
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
+
+import { useSearchParams } from 'next/navigation';
 
 import { FaqElement, Footer } from 'client/components';
 
@@ -24,6 +26,14 @@ const FaqPage = () => {
   const [keyword, setKeyword] = useState<string>('');
   const [faqStates, setFaqStates] = useState<{ [key: number]: boolean }>({});
   const [isPageChanging, setIsPageChanging] = useState<boolean>(false);
+
+  const searchParams = useSearchParams();
+
+  useEffect(() => {
+    if (searchParams.get('dropdown') === 'open' && Element.length > 0) {
+      setFaqStates({ 0: true });
+    }
+  }, [searchParams]);
 
   const totalItems = Element.filter((item) => item.title.toLowerCase().includes(keyword));
   const totalPages = Math.ceil(totalItems.length / ITEMS_PER_PAGE);

--- a/apps/client/src/pageContainer/FaqPage/index.tsx
+++ b/apps/client/src/pageContainer/FaqPage/index.tsx
@@ -35,7 +35,7 @@ const FaqPageComponent = () => {
   const totalPages = Math.ceil(totalItems.length / ITEMS_PER_PAGE);
 
   useEffect(() => {
-    if (searchParams.get('dropdown') === 'open' && Element.length > 0) {
+    if (searchParams.get('openIndex') === '0' && Element.length > 0) {
       setFaqStates({ 0: true });
     }
   }, [searchParams]);
@@ -67,7 +67,7 @@ const FaqPageComponent = () => {
       };
       if (!newFaqStates[index]) {
         const newSearchParams = new URLSearchParams(searchParams.toString());
-        newSearchParams.delete('dropdown');
+        newSearchParams.delete('openIndex');
         router.replace(`${pathname}?${newSearchParams.toString()}`);
       }
       return newFaqStates;


### PR DESCRIPTION
## 개요 💡

> "바로가기" 버튼 클릭 시 드롭다운이 나타나도록 수정했습니다.

## 작업 목적

여러 계정으로 로그인하는 방법을 더욱 쉽게 안내하기 위해, **"바로가기" 버튼 클릭 시 드롭다운이 활성화되도록 수정**했습니다.

## 변경사항

**기존:**

- "바로가기" 버튼 클릭 시 FAQ 페이지로 이동했으나, 동작이 직관적이지 않아 사용자가 쉽게 인지하기 어려웠음.

**변경:**

- "바로가기" 버튼 클릭 시 로그인 방법을 안내하는 **드롭다운이 나타나도록 기능 추가**
- 사용자가 보다 직관적으로 여러 계정 로그인 방법을 확인할 수 있도록 개선
- 드롭다운을 닫았을 때 URL에서 openIndex 파라미터가 제거되도록 수정

## 개발 후 화면

https://github.com/user-attachments/assets/c6358ae0-102f-4c09-9319-b8a7ce7b06d2


## 테스트 동작

1. 홈 페이지로 이동
2. 스크롤을 내려 **"광주소프트웨어마이스터고등학교 2025 신입생 모집"** 섹션으로 이동
3. **"여러 계정으로 로그인하는 방법 🚦"** 영역에서 **"바로가기" 버튼을 클릭**
4. 여러 계정 로그인 방법을 안내하는 **드롭다운이 정상적으로 나타나는지 확인**
5. 여러 계정 로그인 방법 드롭다운을 닫았을 때, URL에서 openIndex 파라미터가 제거되는지 확인
