### PR TITLE
[hotfix] section5 반응형 수정

### DIFF
--- a/apps/client/src/components/MainPage/Section5/index.tsx
+++ b/apps/client/src/components/MainPage/Section5/index.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import Image from 'next/image';
+
 import { cn } from 'shared/lib/utils';
 
 const Elements = [

--- a/apps/client/src/components/MainPage/Section5/index.tsx
+++ b/apps/client/src/components/MainPage/Section5/index.tsx
@@ -1,7 +1,6 @@
 'use client';
 
 import Image from 'next/image';
-
 import { cn } from 'shared/lib/utils';
 
 const Elements = [
@@ -93,12 +92,23 @@ const Section5 = () => {
             'xs:px-[3.75rem]',
             'smx:px-[5.75rem]',
             'md:px-[8rem]',
+            'max-sm:overflow-x-scroll',
+            'max-sm:flex-nowrap',
+            'max-sm:justify-start',
+            'max-sm:pb-4',
           )}
         >
           {Elements.map((element, index) => (
             <div
               key={index}
-              className={cn('flex', 'w-[26rem]', 'flex-col', 'items-start', 'gap-6')}
+              className={cn(
+                'flex',
+                'w-[26rem]',
+                'flex-col',
+                'items-start',
+                'gap-6',
+                'max-sm:flex-shrink-0',
+              )}
             >
               <Image
                 src={element.Img}

--- a/apps/client/src/components/MainPage/Section5/index.tsx
+++ b/apps/client/src/components/MainPage/Section5/index.tsx
@@ -91,6 +91,7 @@ const Section5 = () => {
             'px-4',
             'px-4',
             'xs:px-[3.75rem]',
+            'smx:px-[5.75rem]',
             'md:px-[8rem]',
           )}
         >

--- a/apps/client/tailwind.config.ts
+++ b/apps/client/tailwind.config.ts
@@ -9,6 +9,8 @@ module.exports = {
 
       sm: '600px',
 
+      'max-sm': { max: '599px' },
+
       smxm: '750px',
 
       smx: '850px',


### PR DESCRIPTION
## 개요 💡

section5 반응형 수정했습니다

## 작업내용 ⌨️

- viewport width 1117px 이하에서 세로로 나열되던 카드들이 viewport width 982px ~ 1023px 구간에서 갑작스럽게 가로로 2, 1 배치가 되는 현상 해결
- viewport width가 600px 밑으로 내려가면 카드들이 가로로 배치되며 가로스크롤 되도록 변경

### 변경 전

https://github.com/user-attachments/assets/504ea1bd-5a9e-4cb7-8ee8-932605e49ad2

### 변경 후

https://github.com/user-attachments/assets/a18a4632-9973-4c3d-9ba8-7a356a63d629