### PR TITLE
[refactor] client/admin의 cn 유틸 제거 및 shared 경로로 통일

### DIFF
--- a/apps/admin/src/lib/utils.ts
+++ b/apps/admin/src/lib/utils.ts
@@ -1,6 +1,0 @@
-import { type ClassValue, clsx } from 'clsx';
-import { twMerge } from 'tailwind-merge';
-
-export function cn(...inputs: ClassValue[]) {
-  return twMerge(clsx(inputs));
-}

--- a/apps/client/src/app/provider.tsx
+++ b/apps/client/src/app/provider.tsx
@@ -7,9 +7,9 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { ToastContainer } from 'react-toastify';
 
 import { ChannelTalk } from 'client/components';
-import { cn } from 'client/lib/utils';
 
 import 'react-toastify/dist/ReactToastify.css';
+import { cn } from 'shared/lib/utils';
 
 const Provider = ({ children }: PropsWithChildren) => {
   const queryClient = new QueryClient({

--- a/apps/client/src/components/ActiveLink/index.tsx
+++ b/apps/client/src/components/ActiveLink/index.tsx
@@ -5,7 +5,8 @@ import { PropsWithChildren } from 'react';
 import Link, { LinkProps } from 'next/link';
 import { usePathname } from 'next/navigation';
 
-import { cn } from 'client/lib/utils';
+import { cn } from 'shared/lib/utils';
+
 
 type ActiveLinkProps = LinkProps & {
   className?: string;

--- a/apps/client/src/components/Header/index.tsx
+++ b/apps/client/src/components/Header/index.tsx
@@ -9,7 +9,8 @@ import Link from 'next/link';
 
 import * as I from 'client/assets';
 import { ActiveLink, LoginDialog } from 'client/components';
-import { cn } from 'client/lib/utils';
+
+import { cn } from 'shared/lib/utils';
 
 import { useGetMyAuthInfo, useGetMyMemberInfo, useLogout } from 'api/hooks';
 

--- a/apps/client/src/components/MainPage/Section2/index.tsx
+++ b/apps/client/src/components/MainPage/Section2/index.tsx
@@ -8,7 +8,8 @@ import {
   Section2Icon5,
   Section2Icon6,
 } from 'client/assets';
-import { cn } from 'client/lib/utils';
+
+import { cn } from 'shared/lib/utils';
 
 const stepsData = [
   {

--- a/apps/client/src/components/MainPage/Section3/index.tsx
+++ b/apps/client/src/components/MainPage/Section3/index.tsx
@@ -4,7 +4,8 @@ import Link from 'next/link';
 
 import * as I from 'client/assets';
 import { RECRUITMENT_PERIOD } from 'client/constants';
-import { cn } from 'client/lib/utils';
+
+import { cn } from 'shared/lib/utils';
 
 const buttonStyle = [
   'font-semibold',

--- a/apps/client/src/lib/utils.ts
+++ b/apps/client/src/lib/utils.ts
@@ -1,6 +1,0 @@
-import { type ClassValue, clsx } from 'clsx';
-import { twMerge } from 'tailwind-merge';
-
-export function cn(...inputs: ClassValue[]) {
-  return twMerge(clsx(inputs));
-}

--- a/apps/client/src/pageContainer/PrintPage/index.tsx
+++ b/apps/client/src/pageContainer/PrintPage/index.tsx
@@ -3,11 +3,11 @@
 import { artsPhysicalSubjectsScoreDetailType, GetMyOneseoType, SexEnum } from 'types';
 
 import { OneseoStatus } from 'client/components';
-import { cn } from 'client/lib/utils';
 
 import { PrintIcon } from 'shared/assets';
 import { Button } from 'shared/components';
 import { ARTS_PHYSICAL_SUBJECTS, GENERAL_SUBJECTS } from 'shared/constants';
+import { cn } from 'shared/lib/utils';
 
 import { useGetMyOneseo } from 'api/hooks';
 


### PR DESCRIPTION
## 개요 💡

`cn` 유틸 함수 임포트를 `shared` 경로로 통합하여 코드 일관성과 재사용성을 높였습니다

## 작업내용 ⌨️

- `apps/client/src/lib/utils.ts` 파일 삭제
- `apps/admin/src/lib/utils.ts` 파일 삭제
- `cn` 유틸 함수를 `client` 경로에서 임포트하던 몇몇의 코드들을 `shared` 경로에서 임포트 하도록 변경
- github에서 폴더가 사라지지 않도록 `apps/admin/src/lib/.gitkeep` 파일 추가

## 기타 🎸

`apps/client/src/pageContainer/PrintPage/index.tsx` 에서 `cn` 유틸 함수를 사용하지 않고 스타일을 적용시키고 있음