### PR TITLE
[fix] FAQ 페이지네이션 및 질문 열기 시 스크롤 이동 버그 수정

### DIFF
--- a/apps/client/src/pageContainer/FaqPage/index.tsx
+++ b/apps/client/src/pageContainer/FaqPage/index.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 
 import { useSearchParams, useRouter, usePathname } from 'next/navigation';
 
@@ -24,10 +24,9 @@ const ITEMS_PER_PAGE = 10;
 const FaqPage = ({ openIndex }: { openIndex?: number }) => {
   const [currentPage, setCurrentPage] = useState<number>(1);
   const [keyword, setKeyword] = useState<string>('');
-  const [faqStates, setFaqStates] = useState<{ [key: number]: boolean }>(
-    openIndex !== undefined ? { [openIndex]: true } : {},
-  );
+  const [faqStates, setFaqStates] = useState<{ [key: number]: boolean }>({});
   const [isPageChanging, setIsPageChanging] = useState<boolean>(false);
+  const [isInitialOpenIndexHandled, setIsInitialOpenIndexHandled] = useState<boolean>(false);
 
   const searchParams = useSearchParams();
   const router = useRouter();
@@ -55,21 +54,30 @@ const FaqPage = ({ openIndex }: { openIndex?: number }) => {
     currentPage * ITEMS_PER_PAGE,
   );
 
-  const toggleFaqContent = (index: number) => {
+  const toggleFaqContent = (index: number, updateUrl = false) => {
     setFaqStates((prevStates) => {
       const isOpen = !prevStates[index];
       const newFaqStates = { [index]: isOpen };
 
-      const newSearchParams = new URLSearchParams(searchParams.toString());
-      if (isOpen) {
-        newSearchParams.set('openIndex', String(index));
-      } else {
-        newSearchParams.delete('openIndex');
+      if (updateUrl) {
+        const newSearchParams = new URLSearchParams(searchParams.toString());
+        if (isOpen) {
+          newSearchParams.set('openIndex', String(index));
+        } else {
+          newSearchParams.delete('openIndex');
+        }
+        router.replace(`${pathname}?${newSearchParams.toString()}`, { scroll: false });
       }
-      router.replace(`${pathname}?${newSearchParams.toString()}`, { scroll: false });
       return newFaqStates;
     });
   };
+
+  useEffect(() => {
+    if (!isInitialOpenIndexHandled && openIndex !== undefined) {
+      setFaqStates({ [openIndex]: true });
+      setIsInitialOpenIndexHandled(true);
+    }
+  }, [openIndex, isInitialOpenIndexHandled]);
 
   return (
     <div className={cn('flex', 'flex-col', 'h-[100vh]', 'justify-between', 'bg-white')}>

--- a/apps/client/src/pageContainer/FaqPage/index.tsx
+++ b/apps/client/src/pageContainer/FaqPage/index.tsx
@@ -66,7 +66,7 @@ const FaqPage = ({ openIndex }: { openIndex?: number }) => {
       } else {
         newSearchParams.delete('openIndex');
       }
-      router.replace(`${pathname}?${newSearchParams.toString()}`);
+      router.replace(`${pathname}?${newSearchParams.toString()}`, { scroll: false });
       return newFaqStates;
     });
   };
@@ -123,17 +123,20 @@ const FaqPage = ({ openIndex }: { openIndex?: number }) => {
             </div>
             <div className={cn('w-full', 'h-[0.0625rem]', 'bg-slate-300')} />
             <div className={cn('flex', 'flex-col', 'gap-4', 'pt-8')}>
-              {currentItems.map((faq, index) => (
-                <FaqElement
-                  key={index}
-                  title={faq.title}
-                  content={faq.content}
-                  keyword={keyword}
-                  showContent={!!faqStates[index]}
-                  onToggle={() => toggleFaqContent(index)}
-                  isPageChanging={isPageChanging}
-                />
-              ))}
+              {currentItems.map((faq, index) => {
+                const globalIndex = (currentPage - 1) * ITEMS_PER_PAGE + index;
+                return (
+                  <FaqElement
+                    key={globalIndex}
+                    title={faq.title}
+                    content={faq.content}
+                    keyword={keyword}
+                    showContent={!!faqStates[globalIndex]}
+                    onToggle={() => toggleFaqContent(globalIndex)}
+                    isPageChanging={isPageChanging}
+                  />
+                );
+              })}
             </div>
           </div>
           {totalPages > 1 && (


### PR DESCRIPTION
## 개요 💡

> FAQ 페이지네이션 및 질문 열기 시 스크롤 이동 버그 수정했습니다.

## 작업내용 ⌨️

- 페이지네이션 처리 시 각 항목에 전역 인덱스(globalIndex)를 사용하여 페이지 간 중복 문제 해결
- 질문 클릭 시 페이지가 상단으로 스크롤되는 문제를 `router.replace(..., { scroll: false })`로 방지

## 화면
### 수정 전
https://github.com/user-attachments/assets/ca4046f4-0722-487e-8daf-2c9017920e4a

openIndex값을 확인해주세요!
![image](https://github.com/user-attachments/assets/002380b4-037c-4128-9a88-7a86fd6f9905)
![image](https://github.com/user-attachments/assets/a3738e56-b46a-4aa7-8398-c3468509bf0e)

### 수정 후

https://github.com/user-attachments/assets/dac21c01-a468-48b2-97d5-e2e53b65b596

openIndex값을 확인해주세요!
![image](https://github.com/user-attachments/assets/01abdd76-1336-4460-ad1d-79a6afed468c)
![image](https://github.com/user-attachments/assets/92fff425-bea5-4c5c-8d1b-ab98a0a7c6f3)

## 이슈
`develop`을 삭제해야하는 상황이 발생하여, 
`develop`을 삭제 하고 다시 생성하는 과정에서 이전 pr이 close되어 다시 생성하게 되었습니다.

해당 이슈에 관련해서는 디스코드 방에 재공유할 예정입니다.