### PR TITLE
[feat] 1차, 최종 합격자 조회 방법 변경

### DIFF
--- a/apps/client/src/app/check-result/layout.tsx
+++ b/apps/client/src/app/check-result/layout.tsx
@@ -1,22 +1,10 @@
 'use client';
 
-import { useGetMyAuthInfo, useGetMyMemberInfo } from 'api';
-import Link from 'next/link';
 import { useSelectedLayoutSegment } from 'next/navigation';
-import {
-  AlertDialog,
-  AlertDialogAction,
-  AlertDialogContent,
-  AlertDialogFooter,
-  AlertDialogHeader,
-  AlertDialogTitle,
-} from 'shared';
 
-import { Footer, LoginDialog } from 'client/components';
+import { Footer } from 'client/components';
 
 import { cn } from 'shared/lib/utils';
-
-const mainUrl = '/';
 
 const Layout = ({
   children,
@@ -24,9 +12,6 @@ const Layout = ({
   children: React.ReactNode;
 }>) => {
   const segment = useSelectedLayoutSegment();
-
-  const { data: authInfo } = useGetMyAuthInfo();
-  const { data: memberInfo } = useGetMyMemberInfo();
 
   return (
     <>
@@ -41,28 +26,6 @@ const Layout = ({
         {children}
       </div>
       <Footer />
-
-      <AlertDialog open={!authInfo?.authReferrerType || !memberInfo?.name}>
-        <AlertDialogContent className="w-[400px]">
-          <AlertDialogHeader>
-            <AlertDialogTitle>
-              <strong>로그인을 먼저 진행해주세요</strong>
-              <br />
-              <br />
-              학부모/ 담임교사 합격확인 시, 보안상의 문제로 본인확인을 위해 회원가입 후 학부모/
-              담임교사의 본인 로그인이 필요합니다. <br />
-              <br /> 빠른 확인을 원하시는 경우, 062-949-6842로 전화주시면 친절히 안내드리겠습니다.{' '}
-              <br /> 번거롭게 해드려 죄송합니다.
-            </AlertDialogTitle>
-          </AlertDialogHeader>
-          <AlertDialogFooter>
-            <LoginDialog />
-            <AlertDialogAction>
-              <Link href={mainUrl}>다음에</Link>
-            </AlertDialogAction>
-          </AlertDialogFooter>
-        </AlertDialogContent>
-      </AlertDialog>
     </>
   );
 };

--- a/apps/client/src/hooks/api/test-result/index.ts
+++ b/apps/client/src/hooks/api/test-result/index.ts
@@ -1,2 +1,4 @@
 export * from './useTestResultAuthCode';
 export * from './useTestResultSendCode';
+export * from './useGetFirstTestResult';
+export * from './useGetFinalTestResult';

--- a/apps/client/src/hooks/api/test-result/useGetFinalTestResult.ts
+++ b/apps/client/src/hooks/api/test-result/useGetFinalTestResult.ts
@@ -8,9 +8,9 @@ interface GetFinalTestResultParams {
   phoneNumber: string;
 }
 
-export const useGetFinalTestResult = (params: GetFinalTestResultParams | null) =>
+export const useGetFinalTestResult = (params: GetFinalTestResultParams | undefined) =>
   useQuery({
-    queryKey: ['finalTestResult', params?.name, params?.birth, params?.phoneNumber],
+    queryKey: ['finalTestResult', params],
     queryFn: () => {
       if (!params) return Promise.resolve(undefined);
       return getFinalTestResult(params.name, params.birth, params.phoneNumber);

--- a/apps/client/src/hooks/api/test-result/useGetFinalTestResult.ts
+++ b/apps/client/src/hooks/api/test-result/useGetFinalTestResult.ts
@@ -1,19 +1,15 @@
 import { useQuery } from '@tanstack/react-query';
 
-import { getFinalTestResult } from 'api';
+import { get, testResultQueryKeys, testResultUrl } from 'api';
+import { minutesToMs } from 'shared';
+import { CheckResultParams, FinalTestResultType } from 'types';
 
-interface GetFinalTestResultParams {
-  name: string;
-  birth: string;
-  phoneNumber: string;
-}
-
-export const useGetFinalTestResult = (params: GetFinalTestResultParams | undefined) =>
+export const useGetFinalTestResult = ({ name, birth, phoneNumber }: CheckResultParams) =>
   useQuery({
-    queryKey: ['finalTestResult', params],
-    queryFn: () => {
-      if (!params) return Promise.resolve(undefined);
-      return getFinalTestResult(params.name, params.birth, params.phoneNumber);
-    },
-    enabled: !!params,
+    queryKey: testResultQueryKeys.getFinalTestResult(name, birth, phoneNumber),
+    queryFn: () =>
+      get<FinalTestResultType>(testResultUrl.getFinalTestResult(name, birth, phoneNumber)),
+    staleTime: minutesToMs(5),
+    gcTime: minutesToMs(5),
+    enabled: !!name && !!birth && !!phoneNumber,
   });

--- a/apps/client/src/hooks/api/test-result/useGetFinalTestResult.ts
+++ b/apps/client/src/hooks/api/test-result/useGetFinalTestResult.ts
@@ -1,0 +1,19 @@
+import { useQuery } from '@tanstack/react-query';
+
+import { getFinalTestResult } from 'api';
+
+interface GetFinalTestResultParams {
+  name: string;
+  birth: string;
+  phoneNumber: string;
+}
+
+export const useGetFinalTestResult = (params: GetFinalTestResultParams | null) =>
+  useQuery({
+    queryKey: ['finalTestResult', params?.name, params?.birth, params?.phoneNumber],
+    queryFn: () => {
+      if (!params) return Promise.resolve(undefined);
+      return getFinalTestResult(params.name, params.birth, params.phoneNumber);
+    },
+    enabled: !!params,
+  });

--- a/apps/client/src/hooks/api/test-result/useGetFirstTestResult.ts
+++ b/apps/client/src/hooks/api/test-result/useGetFirstTestResult.ts
@@ -8,9 +8,9 @@ interface GetFirstTestResultParams {
   phoneNumber: string;
 }
 
-export const useGetFirstTestResult = (params: GetFirstTestResultParams | null) =>
+export const useGetFirstTestResult = (params: GetFirstTestResultParams | undefined) =>
   useQuery({
-    queryKey: ['firstTestResult', params?.name, params?.birth, params?.phoneNumber],
+    queryKey: ['firstTestResult', params],
     queryFn: () => {
       if (!params) return Promise.resolve(undefined);
       return getFirstTestResult(params.name, params.birth, params.phoneNumber);

--- a/apps/client/src/hooks/api/test-result/useGetFirstTestResult.ts
+++ b/apps/client/src/hooks/api/test-result/useGetFirstTestResult.ts
@@ -1,0 +1,19 @@
+import { useQuery } from '@tanstack/react-query';
+
+import { getFirstTestResult } from 'api';
+
+interface GetFirstTestResultParams {
+  name: string;
+  birth: string;
+  phoneNumber: string;
+}
+
+export const useGetFirstTestResult = (params: GetFirstTestResultParams | null) =>
+  useQuery({
+    queryKey: ['firstTestResult', params?.name, params?.birth, params?.phoneNumber],
+    queryFn: () => {
+      if (!params) return Promise.resolve(undefined);
+      return getFirstTestResult(params.name, params.birth, params.phoneNumber);
+    },
+    enabled: !!params,
+  });

--- a/apps/client/src/hooks/api/test-result/useGetFirstTestResult.ts
+++ b/apps/client/src/hooks/api/test-result/useGetFirstTestResult.ts
@@ -1,19 +1,15 @@
 import { useQuery } from '@tanstack/react-query';
 
-import { getFirstTestResult } from 'api';
+import { get, testResultQueryKeys, testResultUrl } from 'api';
+import { minutesToMs } from 'shared';
+import { CheckResultParams, FirstTestResultType } from 'types';
 
-interface GetFirstTestResultParams {
-  name: string;
-  birth: string;
-  phoneNumber: string;
-}
-
-export const useGetFirstTestResult = (params: GetFirstTestResultParams | undefined) =>
+export const useGetFirstTestResult = ({ name, birth, phoneNumber }: CheckResultParams) =>
   useQuery({
-    queryKey: ['firstTestResult', params],
-    queryFn: () => {
-      if (!params) return Promise.resolve(undefined);
-      return getFirstTestResult(params.name, params.birth, params.phoneNumber);
-    },
-    enabled: !!params,
+    queryKey: testResultQueryKeys.getFirstTestResult(name, birth, phoneNumber),
+    queryFn: () =>
+      get<FirstTestResultType>(testResultUrl.getFirstTestResult(name, birth, phoneNumber)),
+    staleTime: minutesToMs(5),
+    gcTime: minutesToMs(5),
+    enabled: !!name && !!birth && !!phoneNumber,
   });

--- a/apps/client/src/pageContainer/CheckFinalResultPage/index.tsx
+++ b/apps/client/src/pageContainer/CheckFinalResultPage/index.tsx
@@ -33,6 +33,7 @@ import { checkFinalTestResultFormType, MyMemberInfoType, MyTotalTestResultType }
 import { PassResultDialog } from 'client/components';
 
 import { cn } from 'shared/lib/utils';
+import formattedBirthDate from 'shared/utils/formatBirth';
 
 const prevUrl = '/check-result';
 
@@ -40,12 +41,6 @@ const PERMIT_YEAR = 50;
 
 interface CheckFinalResultProps {
   isCheckFinalResult: boolean;
-}
-
-interface Birth {
-  year: string;
-  month: string;
-  day: string;
 }
 
 const CheckFinalResultPage = ({ isCheckFinalResult }: CheckFinalResultProps) => {
@@ -66,10 +61,6 @@ const CheckFinalResultPage = ({ isCheckFinalResult }: CheckFinalResultProps) => 
   const birthYear = formMethods.watch('birth.year');
   const birthMonth = formMethods.watch('birth.month');
   const birthDay = formMethods.watch('birth.day');
-
-  const formattedBirthDate = (birth: Birth): string => {
-    return `${birth.year}-${birth.month.padStart(2, '0')}-${birth.day.padStart(2, '0')}`;
-  };
 
   const handleFormSubmit = async ({ name, birth, phoneNumber }: checkFinalTestResultFormType) => {
     const formattedBirth = formattedBirthDate(birth);

--- a/apps/client/src/pageContainer/CheckFinalResultPage/index.tsx
+++ b/apps/client/src/pageContainer/CheckFinalResultPage/index.tsx
@@ -49,11 +49,14 @@ const CheckFinalResultPage = ({ isCheckFinalResult }: CheckFinalResultProps) => 
   const [isDialog, setIsDialog] = useState<boolean>(false);
   const [isButtonClickable, setIsButtonClickable] = useState<boolean>(false);
   const [isFailRequestDialog, setIsFailRequestDialog] = useState<boolean>(false);
-  const [queryParams, setQueryParams] = useState<{
-    name: string;
-    birth: string;
-    phoneNumber: string;
-  } | null>(null);
+  const [queryParams, setQueryParams] = useState<
+    | {
+        name: string;
+        birth: string;
+        phoneNumber: string;
+      }
+    | undefined
+  >(undefined);
   const { push } = useRouter();
 
   const formMethods = useForm<checkFinalTestResultFormType>({

--- a/apps/client/src/pageContainer/CheckFinalResultPage/index.tsx
+++ b/apps/client/src/pageContainer/CheckFinalResultPage/index.tsx
@@ -215,7 +215,7 @@ const CheckFinalResultPage = ({ isCheckFinalResult }: CheckFinalResultProps) => 
         </FormProvider>
       </div>
 
-      {/* <AlertDialog open={!isCheckFinalResult}>
+      <AlertDialog open={!isCheckFinalResult}>
         <AlertDialogContent className="w-[400px]">
           <AlertDialogHeader>
             <AlertDialogTitle>현재 최종 합격 여부를 조회할 수 없는 기간입니다.</AlertDialogTitle>
@@ -226,9 +226,9 @@ const CheckFinalResultPage = ({ isCheckFinalResult }: CheckFinalResultProps) => 
             </AlertDialogAction>
           </AlertDialogFooter>
         </AlertDialogContent>
-      </AlertDialog> */}
+      </AlertDialog>
 
-      {/* <AlertDialog open={isFailRequestDialog}>
+      <AlertDialog open={isFailRequestDialog}>
         <AlertDialogContent className="w-[400px]">
           <AlertDialogHeader>
             <AlertDialogTitle>
@@ -243,7 +243,7 @@ const CheckFinalResultPage = ({ isCheckFinalResult }: CheckFinalResultProps) => 
             </AlertDialogAction>
           </AlertDialogFooter>
         </AlertDialogContent>
-      </AlertDialog> */}
+      </AlertDialog>
 
       <PassResultDialog
         isPassOpen={isDialog}

--- a/apps/client/src/pageContainer/CheckFinalResultPage/index.tsx
+++ b/apps/client/src/pageContainer/CheckFinalResultPage/index.tsx
@@ -49,14 +49,11 @@ const CheckFinalResultPage = ({ isCheckFinalResult }: CheckFinalResultProps) => 
   const [isDialog, setIsDialog] = useState<boolean>(false);
   const [isButtonClickable, setIsButtonClickable] = useState<boolean>(false);
   const [isFailRequestDialog, setIsFailRequestDialog] = useState<boolean>(false);
-  const [queryParams, setQueryParams] = useState<
-    | {
-        name: string;
-        birth: string;
-        phoneNumber: string;
-      }
-    | undefined
-  >(undefined);
+  const [queryParams, setQueryParams] = useState<{
+    name: string;
+    birth: string;
+    phoneNumber: string;
+  }>({ name: '', birth: '', phoneNumber: '' });
   const { push } = useRouter();
 
   const formMethods = useForm<checkFinalTestResultFormType>({
@@ -64,7 +61,7 @@ const CheckFinalResultPage = ({ isCheckFinalResult }: CheckFinalResultProps) => 
     mode: 'onChange',
   });
 
-  const { data, error, isPending } = useGetFinalTestResult(queryParams);
+  const { data, error } = useGetFinalTestResult(queryParams);
 
   const targetYear = new Date().getFullYear();
 
@@ -205,7 +202,7 @@ const CheckFinalResultPage = ({ isCheckFinalResult }: CheckFinalResultProps) => 
                 variant={isButtonClickable ? 'blue' : 'disabled'}
                 className={cn('w-[23.7rem]', 'h-[3.25rem]', 'text-[1rem]/[1.5rem]')}
               >
-                {isPending ? '조회 중...' : '조회하기'}
+                조회하기
               </Button>
               <Link
                 href={prevUrl}

--- a/apps/client/src/pageContainer/CheckFinalResultPage/index.tsx
+++ b/apps/client/src/pageContainer/CheckFinalResultPage/index.tsx
@@ -18,6 +18,7 @@ import {
   CustomFormItem,
   FormControl,
   FormItem,
+  getKoreanDate,
   Input,
   Select,
   SelectContent,
@@ -63,7 +64,7 @@ const CheckFinalResultPage = ({ isCheckFinalResult }: CheckFinalResultProps) => 
 
   const { data, error } = useGetFinalTestResult(queryParams);
 
-  const targetYear = new Date().getFullYear();
+  const targetYear = getKoreanDate().getFullYear();
 
   const birthYear = formMethods.watch('birth.year');
   const birthMonth = formMethods.watch('birth.month');
@@ -98,7 +99,13 @@ const CheckFinalResultPage = ({ isCheckFinalResult }: CheckFinalResultProps) => 
         secondTestPassYn: data.secondTestPassYn,
       });
       setIsDialog(true);
-    } else if (error || (data === undefined && queryParams)) {
+    } else if (
+      (error || data === undefined) &&
+      queryParams &&
+      queryParams.name !== '' &&
+      queryParams.birth !== '' &&
+      queryParams.phoneNumber !== ''
+    ) {
       setIsFailRequestDialog(true);
     }
   }, [data, error, queryParams]);

--- a/apps/client/src/pageContainer/CheckFirstResultPage/index.tsx
+++ b/apps/client/src/pageContainer/CheckFirstResultPage/index.tsx
@@ -6,7 +6,7 @@ import { zodResolver } from '@hookform/resolvers/zod';
 import { getFirstTestResult } from 'api';
 import Link from 'next/link';
 import { useRouter } from 'next/navigation';
-import { useForm } from 'react-hook-form';
+import { FormProvider, useForm } from 'react-hook-form';
 import {
   AlertDialog,
   AlertDialogAction,
@@ -17,7 +17,16 @@ import {
   Button,
   checkFirstTestResultSchema,
   CustomFormItem,
+  FormControl,
+  FormItem,
   Input,
+  Select,
+  SelectContent,
+  SelectGroup,
+  SelectItem,
+  SelectLabel,
+  SelectTrigger,
+  SelectValue,
 } from 'shared';
 import {
   checkFirstTestResultFormType,
@@ -27,18 +36,21 @@ import {
 } from 'types';
 
 import { PassResultDialog } from 'client/components';
-import { useTestResultAuthCode, useTestResultSendCode, useTimer } from 'client/hooks';
 
-import { phoneNumberRegex } from 'shared/constants';
-import { useDebounce } from 'shared/hooks';
 import { cn } from 'shared/lib/utils';
 
 const prevUrl = '/check-result';
 
-const timerSeconde = 180;
+const PERMIT_YEAR = 50;
 
 interface CheckFirstResultPageProps {
   isCheckFirstResult: boolean;
+}
+
+interface Birth {
+  year: string;
+  month: string;
+  day: string;
 }
 
 const CheckFirstResultPage = ({ isCheckFirstResult }: CheckFirstResultPageProps) => {
@@ -46,53 +58,26 @@ const CheckFirstResultPage = ({ isCheckFirstResult }: CheckFirstResultPageProps)
   const [firstTestPassYn, setFirstTestPassYn] = useState<YesNo>();
   const [isDialog, setIsDialog] = useState<boolean>(false);
   const [isButtonClickable, setIsButtonClickable] = useState<boolean>(false);
-  const [isAuthenticationButtonClickable, setIsAuthenticationButtonClickable] =
-    useState<boolean>(false);
-  const [isAuthenticated, setIsAuthenticated] = useState<boolean>(false);
-  const [isFirst, setIsFirst] = useState<boolean>(true);
   const [isFailRequestDialog, setIsFailRequestDialog] = useState<boolean>(false);
   const { push } = useRouter();
 
-  const { register, watch, handleSubmit } = useForm<checkFirstTestResultFormType>({
+  const formMethods = useForm<checkFirstTestResultFormType>({
     resolver: zodResolver(checkFirstTestResultSchema),
     mode: 'onChange',
   });
 
-  const codeDebounce = useDebounce(watch('code'), 500);
+  const targetYear = new Date().getFullYear();
 
-  const { count, startTimer, stopTimer } = useTimer({
-    sec: timerSeconde,
-    setIsFirst: setIsFirst,
-    keepAfterRefresh: false,
-  });
+  const birthYear = formMethods.watch('birth.year');
+  const birthMonth = formMethods.watch('birth.month');
+  const birthDay = formMethods.watch('birth.day');
 
-  const { mutate: mutateSendCode } = useTestResultSendCode({
-    onSuccess: () => {
-      startTimer();
-    },
-    onError: () => {},
-  });
-
-  const { mutate: mutateAuthCode } = useTestResultAuthCode({
-    onSuccess: () => {
-      stopTimer();
-      setIsAuthenticated(true);
-    },
-    onError: () => setIsAuthenticated(false),
-  });
-
-  const handleAuthenticationButtonClick = () => {
-    mutateSendCode({
-      phoneNumber: watch('phoneNumber'),
-    });
+  const formattedBirthDate = (birth: Birth): string => {
+    return `${birth.year}-${birth.month.padStart(2, '0')}-${birth.day.padStart(2, '0')}`;
   };
-
-  const handleFormSubmit = async ({
-    phoneNumber,
-    code,
-    submitCode,
-  }: checkFirstTestResultFormType) => {
-    const data = await getFirstTestResult(phoneNumber, code, submitCode);
+  const handleFormSubmit = async ({ name, birth, phoneNumber }: checkFirstTestResultFormType) => {
+    const formattedBirth = formattedBirthDate(birth);
+    const data = await getFirstTestResult(name, formattedBirth, phoneNumber);
 
     if (!data) return setIsFailRequestDialog(true);
 
@@ -106,31 +91,11 @@ const CheckFirstResultPage = ({ isCheckFirstResult }: CheckFirstResultPageProps)
     push(prevUrl);
   };
 
-  const secToMinFormat = (seconds: number) => {
-    const minutes = Math.floor(seconds / 60);
-    const remainingSeconds = seconds % 60;
-    return `${String(minutes).padStart(2, '0')}:${String(remainingSeconds).padStart(2, '0')}`;
-  };
-
   useEffect(() => {
-    if (!codeDebounce || codeDebounce.length !== 6) return;
-
-    mutateAuthCode({ code: codeDebounce });
-  }, [codeDebounce, mutateAuthCode]);
-
-  useEffect(() => {
-    if (phoneNumberRegex.test(watch('phoneNumber')) && !count) {
-      setIsAuthenticationButtonClickable(true);
-    } else {
-      setIsAuthenticationButtonClickable(false);
-    }
-  }, [watch('phoneNumber'), count]);
-
-  useEffect(() => {
-    if (checkFirstTestResultSchema.safeParse(watch()).success && isAuthenticated)
+    if (checkFirstTestResultSchema.safeParse(formMethods.watch()).success)
       setIsButtonClickable(true);
     else setIsButtonClickable(false);
-  }, [watch()]);
+  }, [formMethods.watch()]);
 
   return (
     <>
@@ -138,77 +103,110 @@ const CheckFirstResultPage = ({ isCheckFirstResult }: CheckFirstResultPageProps)
         <h1 className={cn('text-gray-900', 'text-[1.5rem]/[2rem]', 'font-semibold')}>
           1차 합격자 조회
         </h1>
-        <form
-          onSubmit={handleSubmit(handleFormSubmit)}
-          className={cn('flex', 'flex-col', 'items-center', 'gap-4')}
-        >
-          <CustomFormItem className="gap-1" text="수험번호">
-            <Input {...register('submitCode')} placeholder="접수번호 입력" />
-          </CustomFormItem>
-          <CustomFormItem className="gap-1" text="선생님/부모님 전화번호">
-            <div className={cn('flex', 'gap-2', 'mb-[0.15rem]')}>
-              <div className={cn('w-[18rem]', 'relative')}>
-                <Input {...register('phoneNumber')} placeholder="번호 입력(- 제외)" />
-                {!!count && (
-                  <p
-                    className={cn(
-                      'text-blue-500',
-                      'text-[0.875rem]/[1.25rem]',
-                      'font-medium',
-                      'absolute',
-                      'top-1/2',
-                      'right-4',
-                      '-translate-y-1/2 transform',
-                    )}
+        <FormProvider {...formMethods}>
+          <form
+            onSubmit={formMethods.handleSubmit(handleFormSubmit)}
+            className={cn('flex', 'flex-col', 'items-center', 'gap-4')}
+          >
+            <CustomFormItem className="gap-1" text="수험자 성명">
+              <Input {...formMethods.register('name')} placeholder="수험자 성명 입력" />
+            </CustomFormItem>
+            <CustomFormItem className="gap-1" text="생년월일">
+              <div className={cn('flex', 'gap-2')}>
+                <FormItem>
+                  <Select
+                    onValueChange={(value) => formMethods.setValue('birth.year', value)}
+                    defaultValue={birthYear ?? ''}
                   >
-                    {secToMinFormat(count)}
-                  </p>
-                )}
+                    <FormControl>
+                      <SelectTrigger className="w-[7.5625rem]">
+                        <SelectValue placeholder="년도" />
+                      </SelectTrigger>
+                    </FormControl>
+                    <SelectContent>
+                      <SelectGroup>
+                        <SelectLabel>년도 선택</SelectLabel>
+                        {Array.from({ length: PERMIT_YEAR }, (_, index) => targetYear - index).map(
+                          (year) => (
+                            <SelectItem key={year} value={year.toString()}>
+                              {year}
+                            </SelectItem>
+                          ),
+                        )}
+                      </SelectGroup>
+                    </SelectContent>
+                  </Select>
+                </FormItem>
+                <FormItem>
+                  <Select
+                    onValueChange={(value) => formMethods.setValue('birth.month', value)}
+                    defaultValue={birthMonth ?? ''}
+                  >
+                    <FormControl>
+                      <SelectTrigger className="w-[7.5625rem]">
+                        <SelectValue placeholder="월" />
+                      </SelectTrigger>
+                    </FormControl>
+                    <SelectContent>
+                      <SelectGroup>
+                        <SelectLabel>월 선택</SelectLabel>
+                        {Array.from({ length: 12 }, (_, index) => index + 1).map((month) => (
+                          <SelectItem key={month} value={month.toString()}>
+                            {month}
+                          </SelectItem>
+                        ))}
+                      </SelectGroup>
+                    </SelectContent>
+                  </Select>
+                </FormItem>
+                <FormItem>
+                  <Select
+                    onValueChange={(value) => formMethods.setValue('birth.day', value)}
+                    defaultValue={birthDay ?? ''}
+                  >
+                    <FormControl>
+                      <SelectTrigger className="w-[7.5625rem]">
+                        <SelectValue placeholder="일" />
+                      </SelectTrigger>
+                    </FormControl>
+                    <SelectContent>
+                      <SelectGroup>
+                        <SelectLabel>일 선택</SelectLabel>
+                        {Array.from({ length: 31 }, (_, index) => index + 1).map((day) => (
+                          <SelectItem key={day} value={day.toString()}>
+                            {day}
+                          </SelectItem>
+                        ))}
+                      </SelectGroup>
+                    </SelectContent>
+                  </Select>
+                </FormItem>
               </div>
+            </CustomFormItem>
+            <CustomFormItem className="gap-1" text="수험자 전화번호">
+              <Input
+                {...formMethods.register('phoneNumber')}
+                placeholder="수험자 전화번호 입력(-제외)"
+              />
+            </CustomFormItem>
+            <div className={cn('flex', 'flex-col', 'gap-6', 'items-center')}>
               <Button
-                type="button"
-                disabled={isAuthenticated ? true : isAuthenticationButtonClickable ? false : true}
-                variant={
-                  isAuthenticated
-                    ? 'disabled'
-                    : isAuthenticationButtonClickable
-                      ? 'disabled'
-                      : 'submit'
-                }
-                className="w-[5.25rem]"
-                onClick={handleAuthenticationButtonClick}
+                type="submit"
+                disabled={isButtonClickable ? false : true}
+                variant={isButtonClickable ? 'blue' : 'disabled'}
+                className={cn('w-[23.7rem]', 'h-[3.25rem]', 'text-[1rem]/[1.5rem]')}
               >
-                {isAuthenticated ? '인증됨' : isFirst ? '번호 인증' : '재전송'}
+                조회하기
               </Button>
+              <Link
+                href={prevUrl}
+                className={cn('text-slate-500', 'text-[0.875rem]/[1.5rem]', 'flex')}
+              >
+                이전으로
+              </Link>
             </div>
-            <Input
-              {...register('code')}
-              placeholder="인증번호 6자리 입력"
-              successMessage={isAuthenticated ? '번호 인증이 완료되었습니다' : undefined}
-              errorMessage={
-                !isAuthenticated && !isFirst && count <= 0
-                  ? '번호 인증에 실패하였습니다'
-                  : undefined
-              }
-            />
-          </CustomFormItem>
-          <div className={cn('flex', 'flex-col', 'gap-6', 'items-center')}>
-            <Button
-              type="submit"
-              disabled={isButtonClickable ? false : true}
-              variant={isButtonClickable ? 'blue' : 'disabled'}
-              className={cn('w-[23.7rem]', 'h-[3.25rem]', 'text-[1rem]/[1.5rem]')}
-            >
-              조회하기
-            </Button>
-            <Link
-              href={prevUrl}
-              className={cn('text-slate-500', 'text-[0.875rem]/[1.5rem]', 'flex')}
-            >
-              이전으로
-            </Link>
-          </div>
-        </form>
+          </form>
+        </FormProvider>
       </div>
 
       <AlertDialog open={!isCheckFirstResult}>

--- a/apps/client/src/pageContainer/CheckFirstResultPage/index.tsx
+++ b/apps/client/src/pageContainer/CheckFirstResultPage/index.tsx
@@ -108,8 +108,8 @@ const CheckFirstResultPage = ({ isCheckFirstResult }: CheckFirstResultPageProps)
             onSubmit={formMethods.handleSubmit(handleFormSubmit)}
             className={cn('flex', 'flex-col', 'items-center', 'gap-4')}
           >
-            <CustomFormItem className="gap-1" text="수험자 성명">
-              <Input {...formMethods.register('name')} placeholder="수험자 성명 입력" />
+            <CustomFormItem className="gap-1" text="지원자 성명">
+              <Input {...formMethods.register('name')} placeholder="지원자 성명 입력" />
             </CustomFormItem>
             <CustomFormItem className="gap-1" text="생년월일">
               <div className={cn('flex', 'gap-2')}>
@@ -183,10 +183,10 @@ const CheckFirstResultPage = ({ isCheckFirstResult }: CheckFirstResultPageProps)
                 </FormItem>
               </div>
             </CustomFormItem>
-            <CustomFormItem className="gap-1" text="수험자 전화번호">
+            <CustomFormItem className="gap-1" text="지원자 전화번호">
               <Input
                 {...formMethods.register('phoneNumber')}
-                placeholder="수험자 전화번호 입력(-제외)"
+                placeholder="지원자 전화번호 입력(-제외)"
               />
             </CustomFormItem>
             <div className={cn('flex', 'flex-col', 'gap-6', 'items-center')}>

--- a/apps/client/src/pageContainer/CheckFirstResultPage/index.tsx
+++ b/apps/client/src/pageContainer/CheckFirstResultPage/index.tsx
@@ -18,6 +18,7 @@ import {
   CustomFormItem,
   FormControl,
   FormItem,
+  getKoreanDate,
   Input,
   Select,
   SelectContent,
@@ -68,7 +69,7 @@ const CheckFirstResultPage = ({ isCheckFirstResult }: CheckFirstResultPageProps)
 
   const { data, error } = useGetFirstTestResult(queryParams);
 
-  const targetYear = new Date().getFullYear();
+  const targetYear = getKoreanDate().getFullYear();
 
   const birthYear = formMethods.watch('birth.year');
   const birthMonth = formMethods.watch('birth.month');
@@ -99,7 +100,13 @@ const CheckFirstResultPage = ({ isCheckFirstResult }: CheckFirstResultPageProps)
       setName(data.name);
       setFirstTestPassYn(data.firstTestPassYn!);
       setIsDialog(true);
-    } else if (error || (data === undefined && queryParams)) {
+    } else if (
+      (error || data === undefined) &&
+      queryParams &&
+      queryParams.name !== '' &&
+      queryParams.birth !== '' &&
+      queryParams.phoneNumber !== ''
+    ) {
       setIsFailRequestDialog(true);
     }
   }, [data, error, queryParams]);

--- a/apps/client/src/pageContainer/CheckFirstResultPage/index.tsx
+++ b/apps/client/src/pageContainer/CheckFirstResultPage/index.tsx
@@ -54,11 +54,14 @@ const CheckFirstResultPage = ({ isCheckFirstResult }: CheckFirstResultPageProps)
   const [isDialog, setIsDialog] = useState<boolean>(false);
   const [isButtonClickable, setIsButtonClickable] = useState<boolean>(false);
   const [isFailRequestDialog, setIsFailRequestDialog] = useState<boolean>(false);
-  const [queryParams, setQueryParams] = useState<{
-    name: string;
-    birth: string;
-    phoneNumber: string;
-  } | null>(null);
+  const [queryParams, setQueryParams] = useState<
+    | {
+        name: string;
+        birth: string;
+        phoneNumber: string;
+      }
+    | undefined
+  >(undefined);
   const { push } = useRouter();
 
   const formMethods = useForm<checkFirstTestResultFormType>({

--- a/apps/client/src/pageContainer/CheckFirstResultPage/index.tsx
+++ b/apps/client/src/pageContainer/CheckFirstResultPage/index.tsx
@@ -38,6 +38,7 @@ import {
 import { PassResultDialog } from 'client/components';
 
 import { cn } from 'shared/lib/utils';
+import formattedBirthDate from 'shared/utils/formatBirth';
 
 const prevUrl = '/check-result';
 
@@ -45,12 +46,6 @@ const PERMIT_YEAR = 50;
 
 interface CheckFirstResultPageProps {
   isCheckFirstResult: boolean;
-}
-
-interface Birth {
-  year: string;
-  month: string;
-  day: string;
 }
 
 const CheckFirstResultPage = ({ isCheckFirstResult }: CheckFirstResultPageProps) => {
@@ -72,9 +67,6 @@ const CheckFirstResultPage = ({ isCheckFirstResult }: CheckFirstResultPageProps)
   const birthMonth = formMethods.watch('birth.month');
   const birthDay = formMethods.watch('birth.day');
 
-  const formattedBirthDate = (birth: Birth): string => {
-    return `${birth.year}-${birth.month.padStart(2, '0')}-${birth.day.padStart(2, '0')}`;
-  };
   const handleFormSubmit = async ({ name, birth, phoneNumber }: checkFirstTestResultFormType) => {
     const formattedBirth = formattedBirthDate(birth);
     const data = await getFirstTestResult(name, formattedBirth, phoneNumber);

--- a/apps/client/src/pageContainer/CheckFirstResultPage/index.tsx
+++ b/apps/client/src/pageContainer/CheckFirstResultPage/index.tsx
@@ -54,14 +54,11 @@ const CheckFirstResultPage = ({ isCheckFirstResult }: CheckFirstResultPageProps)
   const [isDialog, setIsDialog] = useState<boolean>(false);
   const [isButtonClickable, setIsButtonClickable] = useState<boolean>(false);
   const [isFailRequestDialog, setIsFailRequestDialog] = useState<boolean>(false);
-  const [queryParams, setQueryParams] = useState<
-    | {
-        name: string;
-        birth: string;
-        phoneNumber: string;
-      }
-    | undefined
-  >(undefined);
+  const [queryParams, setQueryParams] = useState<{
+    name: string;
+    birth: string;
+    phoneNumber: string;
+  }>({ name: '', birth: '', phoneNumber: '' });
   const { push } = useRouter();
 
   const formMethods = useForm<checkFirstTestResultFormType>({
@@ -69,7 +66,7 @@ const CheckFirstResultPage = ({ isCheckFirstResult }: CheckFirstResultPageProps)
     mode: 'onChange',
   });
 
-  const { data, error, isPending } = useGetFirstTestResult(queryParams);
+  const { data, error } = useGetFirstTestResult(queryParams);
 
   const targetYear = new Date().getFullYear();
 
@@ -206,7 +203,7 @@ const CheckFirstResultPage = ({ isCheckFirstResult }: CheckFirstResultPageProps)
                 variant={isButtonClickable ? 'blue' : 'disabled'}
                 className={cn('w-[23.7rem]', 'h-[3.25rem]', 'text-[1rem]/[1.5rem]')}
               >
-                {isPending ? '조회 중...' : '조회하기'}
+                조회하기
               </Button>
               <Link
                 href={prevUrl}

--- a/packages/api/src/apis/test-result/getFinalTestResult.ts
+++ b/packages/api/src/apis/test-result/getFinalTestResult.ts
@@ -9,13 +9,13 @@ import { FinalTestResultType } from 'types';
 import { get, testResultUrl } from 'api/libs';
 
 export const getFinalTestResult = async (
+  name: string,
+  birth: string,
   phoneNumber: string,
-  code: string,
-  examinationNumber: string,
 ): Promise<FinalTestResultType | undefined> => {
   try {
     const finalTestResult = await get<FinalTestResultType>(
-      testResultUrl.getFinalTestResult(phoneNumber, code, examinationNumber),
+      testResultUrl.getFinalTestResult(name, birth, phoneNumber),
     );
 
     return finalTestResult;

--- a/packages/api/src/apis/test-result/getFirstTestResult.ts
+++ b/packages/api/src/apis/test-result/getFirstTestResult.ts
@@ -9,13 +9,13 @@ import { FirstTestResultType } from 'types';
 import { get, testResultUrl } from 'api/libs';
 
 export const getFirstTestResult = async (
+  name: string,
+  birth: string,
   phoneNumber: string,
-  code: string,
-  submitCode: string,
 ): Promise<FirstTestResultType | undefined> => {
   try {
     const finalTestResult = await get<FirstTestResultType>(
-      testResultUrl.getFirstTestResult(phoneNumber, code, submitCode),
+      testResultUrl.getFirstTestResult(name, birth, phoneNumber),
     );
 
     return finalTestResult;

--- a/packages/api/src/libs/queryKeys.ts
+++ b/packages/api/src/libs/queryKeys.ts
@@ -40,3 +40,22 @@ export const operationQueryKeys = {
   postFirstResult: () => ['operation', 'first', 'result'],
   postSecondResult: () => ['operation', 'second', 'result'],
 };
+
+export const testResultQueryKeys = {
+  getFirstTestResult: (name: string, birth: string, phoneNumber: string) => [
+    'test',
+    'result',
+    'first',
+    name,
+    birth,
+    phoneNumber,
+  ],
+  getFinalTestResult: (name: string, birth: string, phoneNumber: string) => [
+    'test',
+    'result',
+    'final',
+    name,
+    birth,
+    phoneNumber,
+  ],
+};

--- a/packages/api/src/libs/requestUrlController.ts
+++ b/packages/api/src/libs/requestUrlController.ts
@@ -69,7 +69,7 @@ export const testResultUrl = {
   postSendCode: () => '/test-result/v3/send-code',
   postAuthCode: () => '/test-result/v3/auth-code',
   getFirstTestResult: (name: string, birth: string, phoneNumber: string) =>
-    `/test-result/v3/public/first-test?&name=${name}&birth=${birth}phoneNumber=${phoneNumber}`,
+    `/test-result/v3/public/first-test?&name=${name}&birth=${birth}&phoneNumber=${phoneNumber}`,
   getFinalTestResult: (name: string, birth: string, phoneNumber: string) =>
-    `/test-result/v3/public/second-test?&name=${name}&birth=${birth}phoneNumber=${phoneNumber}`,
+    `/test-result/v3/public/second-test?&name=${name}&birth=${birth}&phoneNumber=${phoneNumber}`,
 } as const;

--- a/packages/api/src/libs/requestUrlController.ts
+++ b/packages/api/src/libs/requestUrlController.ts
@@ -68,8 +68,8 @@ export const opetaionUrl = {
 export const testResultUrl = {
   postSendCode: () => '/test-result/v3/send-code',
   postAuthCode: () => '/test-result/v3/auth-code',
-  getFirstTestResult: (phoneNumber: string, code: string, submitCode: string) =>
-    `/test-result/v3/first-test?phoneNumber=${phoneNumber}&code=${code}&submitCode=${submitCode}`,
-  getFinalTestResult: (phoneNumber: string, code: string, examinationNumber: string) =>
-    `/test-result/v3/second-test?phoneNumber=${phoneNumber}&code=${code}&examinationNumber=${examinationNumber}`,
+  getFirstTestResult: (name: string, birth: string, phoneNumber: string) =>
+    `/test-result/v3/public/first-test?&name=${name}&birth=${birth}phoneNumber=${phoneNumber}`,
+  getFinalTestResult: (name: string, birth: string, phoneNumber: string) =>
+    `/test-result/v3/public/second-test?&name=${name}&birth=${birth}phoneNumber=${phoneNumber}`,
 } as const;

--- a/packages/shared/src/constants/regex.ts
+++ b/packages/shared/src/constants/regex.ts
@@ -1,1 +1,2 @@
 export const phoneNumberRegex = /^[0-9]{11}$/;
+export const koreanNameRegex = /^[가-힣]{2,}$/;

--- a/packages/shared/src/schemas/birthSchema.ts
+++ b/packages/shared/src/schemas/birthSchema.ts
@@ -1,0 +1,16 @@
+import { z } from 'zod';
+
+export const birthSchema = z.object({
+  year: z
+    .string()
+    .regex(/^\d{4}$/, { message: '유효한 연도를 선택해주세요.' })
+    .min(1, { message: '연도를 선택해주세요.' }),
+  month: z
+    .string()
+    .regex(/^\d{1,2}$/, { message: '유효한 월을 선택해주세요.' })
+    .min(1, { message: '월을 선택해주세요.' }),
+  day: z
+    .string()
+    .regex(/^\d{1,2}$/, { message: '유효한 일을 선택해주세요.' })
+    .min(1, { message: '일을 선택해주세요.' }),
+});

--- a/packages/shared/src/schemas/checkFinalTestResultSchema.ts
+++ b/packages/shared/src/schemas/checkFinalTestResultSchema.ts
@@ -1,11 +1,15 @@
 import { z } from 'zod';
 
-import { phoneNumberRegex } from 'shared/constants';
+import { koreanNameRegex, phoneNumberRegex } from 'shared/constants';
+
+import { birthSchema } from './birthSchema';
 
 export const checkFinalTestResultSchema = z.object({
   phoneNumber: z
     .string()
     .refine((phoneNumber) => phoneNumberRegex.test(phoneNumber), '전화번호 형식에 맞지 않습니다.'),
-  code: z.string().length(6, '인증번호 형식에 맞지 않습니다.'),
-  examinationNumber: z.string(),
+  name: z.string().refine((name) => koreanNameRegex.test(name), {
+    message: '이름은 한글 2글자 이상이어야 합니다.',
+  }),
+  birth: birthSchema,
 });

--- a/packages/shared/src/schemas/checkFirstTestResultSchema.ts
+++ b/packages/shared/src/schemas/checkFirstTestResultSchema.ts
@@ -1,11 +1,15 @@
 import { z } from 'zod';
 
-import { phoneNumberRegex } from 'shared/constants';
+import { koreanNameRegex, phoneNumberRegex } from 'shared/constants';
+
+import { birthSchema } from './birthSchema';
 
 export const checkFirstTestResultSchema = z.object({
   phoneNumber: z
     .string()
     .refine((phoneNumber) => phoneNumberRegex.test(phoneNumber), '전화번호 형식에 맞지 않습니다.'),
-  code: z.string().length(6, '인증번호 형식에 맞지 않습니다.'),
-  submitCode: z.string(),
+  name: z.string().refine((val) => koreanNameRegex.test(val), {
+    message: '이름은 한글 2글자 이상이어야 합니다.',
+  }),
+  birth: birthSchema,
 });

--- a/packages/shared/src/schemas/index.ts
+++ b/packages/shared/src/schemas/index.ts
@@ -4,3 +4,4 @@ export * from './step1Schema';
 export * from './step2Schema';
 export * from './step3Schema';
 export * from './step4Schema';
+export * from './birthSchema';

--- a/packages/shared/src/utils/formatBirth.ts
+++ b/packages/shared/src/utils/formatBirth.ts
@@ -1,0 +1,16 @@
+interface Birth {
+  year: string;
+  month: string;
+  day: string;
+}
+
+/**
+ * 생년월일 형식 변환
+ * @param birth 생년월일 객체
+ * @returns YYYY-MM-DD 형식 변환된 생년월일 문자열
+ */
+const formattedBirthDate = (birth: Birth): string => {
+  return `${birth.year}-${birth.month.padStart(2, '0')}-${birth.day.padStart(2, '0')}`;
+};
+
+export default formattedBirthDate;

--- a/packages/shared/src/utils/index.ts
+++ b/packages/shared/src/utils/index.ts
@@ -5,3 +5,4 @@ export { default as plusAll } from './plusAll';
 export { default as dataUrltoFile } from './dataUrltoFile';
 export { default as getValuesByEnum } from './getValuesByEnum';
 export * from './scroll';
+export * from './formatBirth';

--- a/packages/types/src/check-result.ts
+++ b/packages/types/src/check-result.ts
@@ -1,0 +1,5 @@
+export interface CheckResultParams {
+  name: string;
+  birth: string;
+  phoneNumber: string;
+}

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -7,3 +7,4 @@ export * from "./operation";
 export * from "./form";
 export * from "./step";
 export * from "./value";
+export * from "./check-result";


### PR DESCRIPTION
## 개요 💡

사용자가 로그인 없이, 이름 + 생년월일(8자) + 전화번호로 조회하도록 변경했습니다

## 작업내용 ⌨️

* 수험번호 + 부모님/선생님 전화번호로 조회 ->  이름 + 생년월일(8자) + 전화번호로 조회
* 생년월일 입력을 select로 설정
* `/check-result`에 접근시 나왔던 로그인 알림 모달창 삭제
* 합불 조회 api 엔드포인트 교체 & 쿼리스트링 수정
* 생년월일(8자) 스키마 생성
* 1차, 최종 조회 폼 스키마 변경

https://github.com/user-attachments/assets/25d1d697-8aa3-4061-adc8-e0a7db3f576d




## 기타

빠른 개발을 위해 ui적인 부분은 임의로 지정해뒀습니다
추후에 디자인이 제공된다면 수정하겠습니다
