### PR TITLE
[fix]정기베포 기간 수정

### DIFF
--- a/.github/workflows/regular-deploy.yml
+++ b/.github/workflows/regular-deploy.yml
@@ -2,7 +2,7 @@ name: regular deploy PR creation
 
 on:
   schedule:
-    - cron: "0 0 */14 * *"
+    - cron: "0 0 1,15 * *"
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
## 개요 💡

정기베포 github action의 기간을 수정했습니다

## 작업내용 ⌨️

기존에 사용하던 `cron: "0 0 */14 * *"` 설정은 매월 기준으로 주기가 초기화되어, 14일마다 실행되길 원했던 의도와 달리 매월 1일, 15일, 29일에 동작했습니다.
이에 매달 1일과 15일에만 Action이 실행되도록 cron 값을 수정하였습니다.
