### PR TITLE
[fix] 검정고시가 아닌 경우 schoolName, schoolAddress가 null이면 빈 문자열로 초기화

### DIFF
--- a/packages/shared/src/components/register/Step2Register/index.tsx
+++ b/packages/shared/src/components/register/Step2Register/index.tsx
@@ -1,5 +1,7 @@
 'use client';
 
+import { useEffect } from 'react';
+
 import { UseFormRegister, UseFormReset, UseFormSetValue, UseFormWatch } from 'react-hook-form';
 import {
   DesireMajorValueEnum,
@@ -128,6 +130,13 @@ const Step2Register = ({ register, setValue, watch, reset }: Step2RegisterProps)
         return;
     }
   };
+
+  useEffect(() => {
+    if (!isGED && watch('schoolName') === null) {
+      setValue('schoolName', '');
+      setValue('schoolAddress', '');
+    }
+  }, []);
 
   return (
     <div className={cn('flex', 'w-full', 'flex-col', 'items-start', 'gap-10')}>


### PR DESCRIPTION
## 개요 💡

Step2Register 컴포넌트 마운트 시 schoolName, schoolAddress가 null이 기본값으로 주어지는 문제가 있었어서, 검정고시가 아닌 경우 schoolName, schoolAddress가 null이면 빈 문자열로 초기화하도록 변경하였습니다

## 작업내용 ⌨️

- 컴포넌트 마운트 시 검정고시가 아닌 경우 schoolName, schoolAddress가 null이면 빈 문자열로 초기화