### PR TITLE
[refactor] OAuth flow 변경

### DIFF
--- a/apps/admin/src/app/callback/page.tsx
+++ b/apps/admin/src/app/callback/page.tsx
@@ -1,0 +1,5 @@
+import { CallbackPage } from 'admin/pageContainer';
+
+export default function Callback({ searchParams }: { searchParams: { code: string } }) {
+  return <CallbackPage code={searchParams.code} />;
+}

--- a/apps/admin/src/pageContainer/CallbackPage/index.tsx
+++ b/apps/admin/src/pageContainer/CallbackPage/index.tsx
@@ -6,6 +6,8 @@ import { useOAuthLogin } from 'api';
 import { useRouter } from 'next/navigation';
 import { toast } from 'react-toastify';
 
+import { cn } from 'shared/lib/utils';
+
 const CallbackPage = ({ code }: { code: string }) => {
   const router = useRouter();
 
@@ -44,8 +46,8 @@ const CallbackPage = ({ code }: { code: string }) => {
   }, [code, googleLogin, router]);
 
   return (
-    <div className="flex h-screen items-center justify-center">
-      <div className="text-lg font-medium">로그인 처리 중...</div>
+    <div className={cn('flex', 'h-[calc(100vh-4.625rem)]', 'items-center', 'justify-center')}>
+      <div className={cn('text-lg', 'font-medium')}>로그인 처리 중...</div>
     </div>
   );
 };

--- a/apps/admin/src/pageContainer/CallbackPage/index.tsx
+++ b/apps/admin/src/pageContainer/CallbackPage/index.tsx
@@ -1,0 +1,53 @@
+'use client';
+
+import { useEffect } from 'react';
+
+import { useOAuthLogin } from 'api';
+import { useRouter } from 'next/navigation';
+import { toast } from 'react-toastify';
+
+const CallbackPage = ({ code }: { code: string }) => {
+  const router = useRouter();
+
+  const { mutate: googleLogin } = useOAuthLogin('google', {
+    onSuccess: () => {
+      router.replace('/');
+      toast.success('로그인에 성공했습니다.');
+    },
+    onError: () => {
+      router.replace('/');
+      toast.error('로그인에 실패했습니다.');
+    },
+  });
+
+  useEffect(() => {
+    if (!code) {
+      router.replace('/');
+      return;
+    }
+
+    const provider = window.sessionStorage.getItem('oauthProvider');
+    if (!provider) {
+      router.replace('/');
+      toast.error('로그인에 실패했습니다.');
+      return;
+    }
+
+    if (provider === 'google') {
+      googleLogin(code);
+    } else {
+      router.replace('/');
+      toast.error('로그인에 실패했습니다.');
+    }
+
+    window.sessionStorage.removeItem('oauthProvider');
+  }, [code, googleLogin, router]);
+
+  return (
+    <div className="flex h-screen items-center justify-center">
+      <div className="text-lg font-medium">로그인 처리 중...</div>
+    </div>
+  );
+};
+
+export default CallbackPage;

--- a/apps/admin/src/pageContainer/index.ts
+++ b/apps/admin/src/pageContainer/index.ts
@@ -1,3 +1,4 @@
 export { default as LoginPage } from './LoginPage';
 export { default as MainPage } from './MainPage';
 export { default as TicketPage } from './TicketPage';
+export { default as CallbackPage } from './CallbackPage';

--- a/apps/client/src/app/callback/page.tsx
+++ b/apps/client/src/app/callback/page.tsx
@@ -1,0 +1,5 @@
+import { CallbackPage } from 'client/pageContainer';
+
+export default function Callback({ searchParams }: { searchParams: { code: string } }) {
+  return <CallbackPage code={searchParams.code} />;
+}

--- a/apps/client/src/pageContainer/CallbackPage/index.tsx
+++ b/apps/client/src/pageContainer/CallbackPage/index.tsx
@@ -1,0 +1,68 @@
+'use client';
+
+import { useEffect } from 'react';
+
+import { useOAuthLogin } from 'api';
+import { useRouter } from 'next/navigation';
+import { toast } from 'react-toastify';
+
+import { cn } from 'shared/lib/utils';
+
+const CallbackPage = ({ code }: { code: string }) => {
+  const router = useRouter();
+
+  const { mutate: googleLogin } = useOAuthLogin('google', {
+    onSuccess: () => {
+      router.replace('/');
+      toast.success('로그인에 성공했습니다.');
+    },
+    onError: () => {
+      router.replace('/');
+      toast.error('로그인에 실패했습니다.');
+    },
+  });
+
+  const { mutate: kakaoLogin } = useOAuthLogin('kakao', {
+    onSuccess: () => {
+      router.replace('/');
+      toast.success('로그인에 성공했습니다.');
+    },
+    onError: () => {
+      router.replace('/');
+      toast.error('로그인에 실패했습니다.');
+    },
+  });
+
+  useEffect(() => {
+    if (!code) {
+      router.replace('/');
+      return;
+    }
+
+    const provider = window.sessionStorage.getItem('oauthProvider');
+    if (!provider) {
+      router.replace('/');
+      toast.error('로그인에 실패했습니다.');
+      return;
+    }
+
+    if (provider === 'google') {
+      googleLogin(code);
+    } else if (provider === 'kakao') {
+      kakaoLogin(code);
+    } else {
+      router.replace('/');
+      toast.error('로그인에 실패했습니다.');
+    }
+
+    window.sessionStorage.removeItem('oauthProvider');
+  }, [code, googleLogin, kakaoLogin, router]);
+
+  return (
+    <div className={cn('flex', 'h-[calc(100vh-4.625rem)]', 'items-center', 'justify-center')}>
+      <div className={cn('text-lg', 'font-medium')}>로그인 처리 중...</div>
+    </div>
+  );
+};
+
+export default CallbackPage;

--- a/apps/client/src/pageContainer/index.ts
+++ b/apps/client/src/pageContainer/index.ts
@@ -12,3 +12,4 @@ export { default as IntroducePage } from './IntroducePage';
 export { default as CheckResultPage } from './CheckResultPage';
 export { default as CheckFirstResultPage } from './CheckFirstResultPage';
 export { default as CheckFinalResultPage } from './CheckFinalResultPage';
+export { default as CallbackPage } from './CallbackPage';

--- a/packages/api/src/hooks/api/auth/index.ts
+++ b/packages/api/src/hooks/api/auth/index.ts
@@ -1,1 +1,2 @@
 export * from './useLogout';
+export * from './useOAuthLogin';

--- a/packages/api/src/hooks/api/auth/useOAuthLogin.ts
+++ b/packages/api/src/hooks/api/auth/useOAuthLogin.ts
@@ -1,0 +1,20 @@
+import { useMutation, type UseMutationOptions } from '@tanstack/react-query';
+
+import type { AxiosError } from 'axios';
+
+import { authUrl, post } from 'api/libs';
+
+interface ReturnDataType {
+  status: string;
+  code: number;
+  message: string;
+}
+
+export const useOAuthLogin = (
+  provider: 'google' | 'kakao',
+  options?: UseMutationOptions<ReturnDataType, AxiosError, string>,
+) =>
+  useMutation({
+    mutationFn: (code: string) => post<ReturnDataType>(authUrl.postLogin(provider), { code }),
+    ...options,
+  });

--- a/packages/api/src/libs/requestUrlController.ts
+++ b/packages/api/src/libs/requestUrlController.ts
@@ -13,7 +13,7 @@ export const exampleUrl = {
 } as const;
 
 export const authUrl = {
-  getLogin: (provider: 'google' | 'kakao') => `/auth/v3/oauth2/authorization/${provider}`,
+  postLogin: (provider: 'google' | 'kakao') => `/auth/v3/auth/${provider}`,
   getLogout: () => '/auth/v3/logout',
 } as const;
 

--- a/packages/shared/src/components/ui/LoginButton/index.tsx
+++ b/packages/shared/src/components/ui/LoginButton/index.tsx
@@ -47,6 +47,11 @@ const LoginButton = React.forwardRef<HTMLButtonElement, LoginButtonProps>(
     React.useEffect(() => {
       if (typeof window !== 'undefined') {
         setRedirectUri(`${window.location.origin}/callback`);
+      }
+    }, []);
+
+    React.useEffect(() => {
+      if (redirectUri) {
         setGoogleLoginUrl(
           `https://accounts.google.com/o/oauth2/v2/auth?client_id=${process.env.NEXT_PUBLIC_GOOGLE_CLIENT_ID}&redirect_uri=${redirectUri}&response_type=code&scope=email profile`,
         );
@@ -54,7 +59,7 @@ const LoginButton = React.forwardRef<HTMLButtonElement, LoginButtonProps>(
           `https://kauth.kakao.com/oauth/authorize?client_id=${process.env.NEXT_PUBLIC_KAKAO_REST_API_KEY}&redirect_uri=${redirectUri}&response_type=code`,
         );
       }
-    }, []);
+    }, [redirectUri]);
 
     const OAuthValues = {
       google: {

--- a/packages/shared/src/components/ui/LoginButton/index.tsx
+++ b/packages/shared/src/components/ui/LoginButton/index.tsx
@@ -8,8 +8,6 @@ import { GoogleIcon, KakaoIcon } from 'shared/assets';
 import { Button } from 'shared/components';
 import { cn } from 'shared/lib/utils';
 
-import { authUrl } from 'api/libs';
-
 const loginButtonVariants = cva(
   cn(
     'text-gray-700',
@@ -42,21 +40,30 @@ interface LoginButtonProps
 
 const LoginButton = React.forwardRef<HTMLButtonElement, LoginButtonProps>(
   ({ className, variant, children, ...props }, ref) => {
+    const REDIRECT_URI = `${window.location.origin}/callback`;
+
+    const GOOGLE_LOGIN_URL = `https://accounts.google.com/o/oauth2/v2/auth?client_id=${process.env.NEXT_PUBLIC_GOOGLE_CLIENT_ID}&redirect_uri=${REDIRECT_URI}&response_type=code&scope=email profile`;
+    const KAKAO_LOGIN_URL = `https://kauth.kakao.com/oauth/authorize?client_id=${process.env.NEXT_PUBLIC_KAKAO_REST_API_KEY}&redirect_uri=${REDIRECT_URI}&response_type=code`;
+
     const OAuthValues = {
       google: {
         icon: <GoogleIcon />,
-        href: authUrl.getLogin('google'),
+        href: GOOGLE_LOGIN_URL,
       },
       kakao: {
         icon: <KakaoIcon />,
-        href: authUrl.getLogin('kakao'),
+        href: KAKAO_LOGIN_URL,
       },
+    };
+
+    const handleOAuthLogin = (provider: 'google' | 'kakao') => {
+      window.sessionStorage.setItem('oauthProvider', provider);
     };
 
     return (
       <>
         {variant && (
-          <a href={`${process.env.NEXT_PUBLIC_API_BASE_URL}${OAuthValues[variant].href}`}>
+          <a href={OAuthValues[variant].href} onClick={() => handleOAuthLogin(variant)}>
             <Button
               ref={ref}
               className={cn(loginButtonVariants({ variant }), className)}

--- a/packages/shared/src/components/ui/LoginButton/index.tsx
+++ b/packages/shared/src/components/ui/LoginButton/index.tsx
@@ -40,19 +40,30 @@ interface LoginButtonProps
 
 const LoginButton = React.forwardRef<HTMLButtonElement, LoginButtonProps>(
   ({ className, variant, children, ...props }, ref) => {
-    const REDIRECT_URI = `${window.location.origin}/callback`;
+    const [redirectUri, setRedirectUri] = React.useState('');
+    const [googleLoginUrl, setGoogleLoginUrl] = React.useState('');
+    const [kakaoLoginUrl, setKakaoLoginUrl] = React.useState('');
 
-    const GOOGLE_LOGIN_URL = `https://accounts.google.com/o/oauth2/v2/auth?client_id=${process.env.NEXT_PUBLIC_GOOGLE_CLIENT_ID}&redirect_uri=${REDIRECT_URI}&response_type=code&scope=email profile`;
-    const KAKAO_LOGIN_URL = `https://kauth.kakao.com/oauth/authorize?client_id=${process.env.NEXT_PUBLIC_KAKAO_REST_API_KEY}&redirect_uri=${REDIRECT_URI}&response_type=code`;
+    React.useEffect(() => {
+      if (typeof window !== 'undefined') {
+        setRedirectUri(`${window.location.origin}/callback`);
+        setGoogleLoginUrl(
+          `https://accounts.google.com/o/oauth2/v2/auth?client_id=${process.env.NEXT_PUBLIC_GOOGLE_CLIENT_ID}&redirect_uri=${redirectUri}&response_type=code&scope=email profile`,
+        );
+        setKakaoLoginUrl(
+          `https://kauth.kakao.com/oauth/authorize?client_id=${process.env.NEXT_PUBLIC_KAKAO_REST_API_KEY}&redirect_uri=${redirectUri}&response_type=code`,
+        );
+      }
+    }, []);
 
     const OAuthValues = {
       google: {
         icon: <GoogleIcon />,
-        href: GOOGLE_LOGIN_URL,
+        href: googleLoginUrl,
       },
       kakao: {
         icon: <KakaoIcon />,
-        href: KAKAO_LOGIN_URL,
+        href: kakaoLoginUrl,
       },
     };
 
@@ -60,21 +71,15 @@ const LoginButton = React.forwardRef<HTMLButtonElement, LoginButtonProps>(
       window.sessionStorage.setItem('oauthProvider', provider);
     };
 
+    if (!redirectUri || !variant) return null;
+
     return (
-      <>
-        {variant && (
-          <a href={OAuthValues[variant].href} onClick={() => handleOAuthLogin(variant)}>
-            <Button
-              ref={ref}
-              className={cn(loginButtonVariants({ variant }), className)}
-              {...props}
-            >
-              {OAuthValues[variant].icon}
-              {children}
-            </Button>
-          </a>
-        )}
-      </>
+      <a href={OAuthValues[variant].href} onClick={() => handleOAuthLogin(variant)}>
+        <Button ref={ref} className={cn(loginButtonVariants({ variant }), className)} {...props}>
+          {OAuthValues[variant].icon}
+          {children}
+        </Button>
+      </a>
     );
   },
 );


### PR DESCRIPTION
## 개요 💡

> OAuth 로그인 후 바로 BE URL로 리다이렉트되어 인증 처리 후 FE로 다시 리다이렉트 해주는 방식인데 만약 인증 처리 중 오류가 발생할 경우 화이트라벨 에러페이지가 사용자에게 노출되어 FE에서 이를 관리할 수가 없습니다.

위와 같은 문제로 인해, 프론트엔드에서 직접 OAuth 인증 요청을 수행한 후, 발급받은 Authorization Code를 백엔드로 REST API 형태로 전달하는 방식으로 변경하였습니다.

## 작업내용 ⌨️

- 로그인 요청 엔드포인트 변경
- useOAuthLogin 훅 제작
- 로그인 버튼 리팩토링
- client, admin callback 페이지 제작

### 관련 문서

https://www.notion.so/OAuth-Flow-22b3f725618580899444fe35740f3e86?source=copy_link

### 기존 flow

사용자가 로그인 버튼을 클릭하면 프론트엔드에서 백엔드의 OAuth 인증 엔드포인트(`/auth/v3/auth/authorization/{provider}`)로 리다이렉트됩니다. 백엔드는 OAuth 제공자와 전체 인증 과정을 처리하며, Authorization Code 수신부터 Access Token 교환, 사용자 정보 처리까지 모든 과정을 담당합니다. 인증 성공 시 프론트엔드로 리다이렉트하지만, 실패 시에는 사용자에게 직접 화이트라벨 에러 페이지를 표시합니다.

### 새로운 flow

사용자가 로그인 버튼을 클릭하면 프론트엔드에서 OAuth 제공자와 직접 통신하여 인증 페이지로 이동합니다. 사용자 인증 완료 후 OAuth 제공자로부터 Authorization Code를 직접 수신하고, 이를 백엔드 API(POST, `/auth/v3/auth/{provider}`)로 전송합니다. 백엔드는 받은 코드로 Access Token 교환 및 사용자 정보 처리를 수행한 후, 성공/실패 여부를 JSON 형태로 응답합니다. 프론트엔드는 이 응답을 바탕으로 적절한 페이지 이동이나 에러 메시지 표시를 처리합니다.

## 관련 issue 🤯

카카오와 구글 OAuth 서비스의 URL 및 리다이렉트 URL을 아직 수정하지 못해 테스트를 진행하지 못한 상태입니다. 관련 계정을 보유하고 계신 희성 선배님께 URL 수정 요청은 드린 상태이며, 반영되는 대로 즉시 테스트를 진행할 예정입니다. 이 점 감안하여 코드 리뷰해 주시면 감사하겠습니다.