### PR TITLE
[fix] 교과 성적 소계 부동소수점 오차 해결

### DIFF
--- a/apps/client/src/components/OneseoStatus/index.tsx
+++ b/apps/client/src/components/OneseoStatus/index.tsx
@@ -193,8 +193,10 @@ const OneseoStatus = ({ oneseo }: OneseoStatusType) => {
           <td className={cn('border', 'border-black')}>
             {oneseo.privacyDetail.graduationType === 'GED'
               ? oneseo.middleSchoolAchievement.gedAvgScore
-              : oneseo.calculatedScore.generalSubjectsScore! +
-                oneseo.calculatedScore.artsPhysicalSubjectsScore!}
+              : (
+                  oneseo.calculatedScore.generalSubjectsScore! +
+                  oneseo.calculatedScore.artsPhysicalSubjectsScore!
+                ).toFixed(2)}
           </td>
         </tr>
         <tr>


### PR DESCRIPTION
## 개요 💡

<img width="3456" height="2234" alt="image" src="https://github.com/user-attachments/assets/4241e28c-b7fc-4bfd-a1ed-14ae09316977" />

사진과 같이 프린트 페이지에서 교과 성적 소계를 계산할 때, 일반 교과 점수와 예체능 교과 점수를 합치는 과정에서 발생한 부동소수점 오차를 해결했습니다.

## 작업내용 ⌨️

- toFixed 사용해서 소수점 2자리 반올림 처리