### PR TITLE
[fix] printPage 예체능 점수 학기별 순서 오류 수정

### DIFF
--- a/apps/client/src/pageContainer/PrintPage/index.tsx
+++ b/apps/client/src/pageContainer/PrintPage/index.tsx
@@ -810,7 +810,6 @@ const ApplicationPage = ({ initialData }: PrintPageProps) => {
                     </tr>
                   </tbody>
                 </table>
-
                 <h2 className={cn('mt-[1.5vh]', 'text-[1.2vh]', 'leading-[2vh]')}>비교과</h2>
                 <table className={cn('w-full', 'border-collapse', 'border', 'text-[1vh]')}>
                   <thead>

--- a/apps/client/src/pageContainer/PrintPage/index.tsx
+++ b/apps/client/src/pageContainer/PrintPage/index.tsx
@@ -44,6 +44,17 @@ const ApplicationPage = ({ initialData }: PrintPageProps) => {
         achievements.slice(9, 12),
       ];
     } else if (isCandidate) {
+      const { liberalSystem } = oneseo.middleSchoolAchievement;
+      if (liberalSystem === '자유학년제') {
+        return [
+          null,
+          null,
+          achievements.slice(0, 3),
+          achievements.slice(3, 6),
+          achievements.slice(6, 9),
+          null,
+        ];
+      }
       return [
         achievements.slice(0, 3),
         achievements.slice(3, 6),
@@ -799,6 +810,7 @@ const ApplicationPage = ({ initialData }: PrintPageProps) => {
                     </tr>
                   </tbody>
                 </table>
+
                 <h2 className={cn('mt-[1.5vh]', 'text-[1.2vh]', 'leading-[2vh]')}>비교과</h2>
                 <table className={cn('w-full', 'border-collapse', 'border', 'text-[1vh]')}>
                   <thead>


### PR DESCRIPTION
## 개요 💡

> printPage 예체능 점수 학기별 순서 오류 수정

## 작업내용 ⌨️

- printPage에서 예체능 교과 점수가 학기 구분 없이 순서대로만 출력되는 문제가 있었습니다.
- 졸업 예정자와 자유학년제 여부를 고려하지 않아, 실제 학기별 성적 배치가 잘못 표시되었습니다.
 (졸업 예정 + 자유학년제 :  2-1학기부터 예체능 성적 배치 해야하지만 1-1학기부터 배치되었음)
- [관련 노션](https://www.notion.so/print-24f3f72561858054ba4edfceab684668?source=copy_link)

## 화면
성적 점수는 예시이니 참고만 해주세요

[수정 전]
<img width="1802" height="450" alt="image" src="https://github.com/user-attachments/assets/44f881e7-8cca-4247-8c30-afa49a35e5fe" />


[수정 후]
<img width="1300" height="357" alt="image" src="https://github.com/user-attachments/assets/a1820e74-b18a-423a-a6af-c64efb00d972" />


## 테스트
- 졸업 예정 + 자유학년제 → 2-1부터 출력 확인
- 졸업 예정 + 일반 → 1-1부터 출력 확인
- 졸업자 → 기존 순서 유지(2-1부터 출력) 확인
