### PR TITLE
[fix] step간 이동시 자유학기제 유지

### DIFF
--- a/packages/shared/src/components/form/FreeSemesterForm/index.tsx
+++ b/packages/shared/src/components/form/FreeSemesterForm/index.tsx
@@ -83,7 +83,8 @@ const FreeSemesterForm = ({
     setTimeout(
       () =>
         ACHIEVEMENT_FIELD_LIST.forEach((field) => {
-          achievementList.some((freeGrade) => freeGrade.field === field)
+          achievementList.some((freeGrade) => freeGrade.field === field) &&
+          !(freeSemester && field === freeSemesterToAchievementField[freeSemester])
             ? setValue(field, watch(field) || [])
             : setValue(field, null);
         }),


### PR DESCRIPTION
## 개요 💡

step간 이동시 자유학기제 유지되지 않던 문제를 수정했습니다

## 작업내용 ⌨️

https://github.com/user-attachments/assets/b10756bb-74e4-4f3f-b664-c0bc1b637fcd

step 이동시 UI상으론 자유학기제가 선택되어 있는것 처럼 보였지만
실제론 `null`이 아닌 빈 배열이 들어가있어, 
성적계산버튼과 원서최종제출 버튼이 활성화 되지 않습니다