### PR TITLE
[fix] 보호자 및 담임 선생님 전화번호 검증 규칙 세분화

### DIFF
--- a/packages/shared/src/constants/regex.ts
+++ b/packages/shared/src/constants/regex.ts
@@ -1,4 +1,3 @@
-export const phoneNumberRegex = /^[0-9]{11}$/;
-export const guardianPhoneNumberRegex = /^010\d{8}$/;
+export const phoneNumberRegex = /^010\d{8}$/;
 export const teacherPhoneNumberRegex = /^0\d{8,10}$/;
 export const koreanNameRegex = /^[가-힣]{2,}$/;

--- a/packages/shared/src/schemas/step3Schema.ts
+++ b/packages/shared/src/schemas/step3Schema.ts
@@ -1,13 +1,13 @@
 import { RelationshipWithGuardianValueEnum } from 'types';
 import { z } from 'zod';
 
-import { guardianPhoneNumberRegex, teacherPhoneNumberRegex } from 'shared/constants';
+import { phoneNumberRegex, teacherPhoneNumberRegex } from 'shared/constants';
 import { getValuesByEnum } from 'shared/utils';
 
 export const step3Schema = z
   .object({
     guardianName: z.string().min(1),
-    guardianPhoneNumber: z.string().regex(guardianPhoneNumberRegex),
+    guardianPhoneNumber: z.string().regex(phoneNumberRegex),
     relationshipWithGuardian: z.enum(getValuesByEnum(RelationshipWithGuardianValueEnum)),
     otherRelationshipWithGuardian: z.nullable(z.string().min(1)),
     schoolTeacherName: z.nullable(z.string().min(1)),


### PR DESCRIPTION
## 개요 💡

> 보호자 및 담임 선생님 전화번호 검증 규칙 세분화 작업했습니다.

## 작업내용 ⌨️

- `step3Schema에`서 **보호자** 전화번호와 **담임 선생님** 전화번호의 유효성 검증 규칙을 분리
- **보호자 전화번호**: '010'으로 시작하는 11자리로 제한
- **담임 선생님 전화번호**: '0'으로 시작하는 9~11자리로 제한

## 화면
[보호자]

https://github.com/user-attachments/assets/c9b4777f-dba9-4f6f-ad26-41b562af8fb0

[담임 선생님]

https://github.com/user-attachments/assets/b3711c6c-c0b5-4027-99cb-4ccd80e7cd99
