### PR TITLE
[fix] OAuth 콜백 후 클라이언트 URL에 www 서브도메인 추가

### DIFF
--- a/apps/client/src/pageContainer/CallbackPage/index.tsx
+++ b/apps/client/src/pageContainer/CallbackPage/index.tsx
@@ -20,7 +20,7 @@ const CallbackPage = ({ code, provider }: { code: string; provider: string }) =>
     // 콜백에서는 항상 클라이언트 메인으로 이동하고, 어드민 로그인 시도 여부를 쿼리로 전달
     const currentOrigin = window.location.origin;
     const isStage = currentOrigin.includes('stage');
-    const clientBaseUrl = isStage ? 'https://stage.hellogsm.kr' : 'https://hellogsm.kr';
+    const clientBaseUrl = isStage ? 'https://www.stage.hellogsm.kr' : 'https://www.hellogsm.kr';
     const nextUrl = provider === 'admin' ? `${clientBaseUrl}/?isAdmin=true` : clientBaseUrl;
     router.replace(nextUrl);
 


### PR DESCRIPTION
## 개요 💡

clientBaseUrl에 누락됐던 www 서브도메인 추가 했습니다.

## 작업내용 ⌨️

- clientBaseUrl에 누락됐던 www 서브도메인 추가 

## 관련 issue 🤯

급하게 해결하느라 브랜치 명이 명확하지 않습니다. 양해 부탁드립니다.
