### PR TITLE
[fix] 콜백 페이지에서 사용자 정보 쿼리 키 수정

### DIFF
--- a/apps/client/src/pageContainer/CallbackPage/index.tsx
+++ b/apps/client/src/pageContainer/CallbackPage/index.tsx
@@ -15,7 +15,7 @@ const CallbackPage = ({ code, provider }: { code: string; provider: string }) =>
   const queryClient = useQueryClient();
 
   const handleLoginSuccess = async () => {
-    await queryClient.invalidateQueries({ queryKey: memberQueryKeys.getMyAuthInfo() });
+    await queryClient.invalidateQueries({ queryKey: memberQueryKeys.getMyMemberInfo() });
 
     // 콜백에서는 항상 클라이언트 메인으로 이동하고, 어드민 로그인 시도 여부를 쿼리로 전달
     const currentOrigin = window.location.origin;


### PR DESCRIPTION
## 개요 💡

https://github.com/themoment-team/hellogsm-front-24/pull/233 pr에서 로그인 후 헤더에 ‘회원가입을 진행해주세요’ 문구가 노출되는 문제를 해결하기 위해 쿼리 키 초기화를 적용했었는데, 키를 잘못 지정한 부분이 있어 올바른 쿼리 키로 수정했습니다.

## 작업내용 ⌨️

- 잘못된 쿼리 키를 올바른 값으로 수정