### PR TITLE
[feat] 메인페이지, 헤더, 푸터 사소한 디자인 조정

### DIFF
--- a/apps/client/src/components/Footer/index.tsx
+++ b/apps/client/src/components/Footer/index.tsx
@@ -69,6 +69,7 @@ const Footer = () => {
             <p
               className={cn(
                 'w-full',
+                'text-[1.125rem]',
                 'text-left',
                 'sm:text-right',
                 'font-normal',
@@ -84,7 +85,7 @@ const Footer = () => {
                 <a
                   key={text}
                   href={link}
-                  className={cn('text-h5', 'font-bold', 'text-slate-600')}
+                  className={cn('text-[1.125rem]/[1.6875rem]', 'font-bold', 'text-slate-600')}
                   target="_blank"
                   rel="noreferrer"
                 >
@@ -95,10 +96,10 @@ const Footer = () => {
           </div>
           <p
             className={cn(
-              'text-body2',
               'w-full',
               'text-right',
               'font-normal',
+              'text-[0.875rem]/[1.25rem]',
               'text-slate-400',
               'hidden',
               'sm:block',

--- a/apps/client/src/components/MainPage/Section1/index.tsx
+++ b/apps/client/src/components/MainPage/Section1/index.tsx
@@ -124,7 +124,7 @@ const Section1 = ({ isServerCurrentActive }: { isServerCurrentActive: boolean })
         </div>
       </div>
 
-      <div className={cn(['absolute', 'bottom-14', ...flexColStyle, 'gap-1', 'z-[3]'])}>
+      <div className={cn(['absolute', 'bottom-14', ...flexColStyle, 'gap-[0.75rem]', 'z-[3]'])}>
         <p
           onClick={scrollToSection2}
           className={cn(

--- a/apps/client/src/components/MainPage/Section2/index.tsx
+++ b/apps/client/src/components/MainPage/Section2/index.tsx
@@ -129,7 +129,7 @@ const Section2 = () => {
             className={cn(
               'text-gray-600',
               'font-normal',
-              'text-[1rem]/[1.5rem]',
+              'text-[1.25rem]/[1.75rem]',
               'text-center',
               'smx:text-left',
             )}

--- a/apps/client/src/components/MainPage/Section3/index.tsx
+++ b/apps/client/src/components/MainPage/Section3/index.tsx
@@ -65,8 +65,9 @@ const Section3 = ({ isServerHealthy }: Section3Props) => {
               ...buttonStyle,
               'text-sky-900',
               'border-sky-900',
-              'px-4',
-              'py-[9px]',
+              'text-[1.25rem]',
+              'px-[2rem]',
+              'py-[0.625rem]',
               'hidden',
               'lg:inline',
             ])}

--- a/apps/client/src/components/MainPage/Section4/index.tsx
+++ b/apps/client/src/components/MainPage/Section4/index.tsx
@@ -91,6 +91,7 @@ const TitleCard = ({ firstText, lastText, icon }: TitleCardProps) => (
       'w-[30rem]',
       'sm:w-[25.1875rem]',
       'md:w-[20rem]',
+      'bg-white',
     )}
   >
     <div className={cn('flex', 'w-[16.4375rem]', 'flex-col', 'items-start')}>

--- a/apps/client/src/components/MainPage/Section5/index.tsx
+++ b/apps/client/src/components/MainPage/Section5/index.tsx
@@ -42,13 +42,14 @@ const Elements = [
 
 const Section5 = () => {
   return (
-    <div className={cn('flex', 'flex-col', 'gap-[4.25rem]', 'bg-white', 'py-[11.25rem]', 'w-full')}>
-      <div className={cn('flex', 'justify-center', 'gap-[3.75rem]', 'flex-col')}>
+    <div className={cn('flex', 'flex-col', 'bg-white', 'py-[11.25rem]', 'w-full')}>
+      <div className={cn('flex', 'justify-center', 'gap-[4.25rem]', 'flex-col')}>
         <div
           className={cn(
             'flex',
             'flex-col',
             'items-center',
+            'gap-[1rem]',
             'pl-[8rem]',
             'px-4',
             'xs:px-[3.75rem]',


### PR DESCRIPTION
## 개요 💡

디자인과 다르게 되어있던 메인페이지 요소들을 디자인에 맞게 수정했습니다.

## 작업내용 ⌨️

- 메인 페이지 폰트 사이즈, 갭 등 수정
- 푸터 폰트 사이즈 조정

## 관련 issue 🤯

피그마 디자인과 다른 부분이 작업한 영역 외에도 많았지만, 지금 당장 모두 수정하기에는 시간이 다소 걸릴 것 같아 우선 눈에 가장 잘 띄는 부분만 수정했습니다.
