### PR TITLE
[fix] 합격자 조회시 중복 모달

### DIFF
--- a/apps/client/src/pageContainer/CheckFinalResultPage/index.tsx
+++ b/apps/client/src/pageContainer/CheckFinalResultPage/index.tsx
@@ -108,7 +108,7 @@ const CheckFinalResultPage = ({ isCheckFinalResult }: CheckFinalResultProps) => 
     ) {
       setIsFailRequestDialog(true);
     }
-  }, [data, error, queryParams]);
+  }, [data, error]);
 
   return (
     <>

--- a/apps/client/src/pageContainer/CheckFirstResultPage/index.tsx
+++ b/apps/client/src/pageContainer/CheckFirstResultPage/index.tsx
@@ -109,7 +109,7 @@ const CheckFirstResultPage = ({ isCheckFirstResult }: CheckFirstResultPageProps)
     ) {
       setIsFailRequestDialog(true);
     }
-  }, [data, error, queryParams]);
+  }, [data, error]);
 
   return (
     <>


### PR DESCRIPTION
## 개요 💡

조회 결과가 조회된 사람 없음 모달과 함께 중복으로 표시되던 현상을 수정했습니다

## 작업내용 ⌨️

`handleFormSubmit` 함수 내에서 `setQueryParams`를 호출하여 `queryParams`의 값이 변경되는데
모달 여부를 관리하는 useEffect의 조건에 `queryParams`가 조건으로 들어가 있어
```tsx
useEffect(() => {
if (data) {
      console.log(1, data, error, queryParams)
      setName(data.name);
      setResultInfo({
        decidedMajor: data.decidedMajor,
        firstTestPassYn: 'YES',
        secondTestPassYn: data.secondTestPassYn,
      });
      setIsDialog(true);
    } else if (
      (error || data === undefined) &&
      queryParams &&
      queryParams.name !== '' &&
      queryParams.birth !== '' &&
      queryParams.phoneNumber !== ''
    ) {
      console.log(2, data, error, queryParams)
      setIsFailRequestDialog(true);
    }
}, [data, error, queryParams]);
```
<img width="569" height="47" alt="image" src="https://github.com/user-attachments/assets/567dfa04-5e5d-40e4-8a45-18f58f67b678" /><br />
queryParams가 변경되어 useEffect가 호출이 되지만 아직 data는 undefined로 아직 오지 않아 ` setIsFailRequestDialog(true);`이 실행되어 `조회된 사람 없음` 모달이 발생하고

<img width="564" height="50" alt="image" src="https://github.com/user-attachments/assets/ef2b1562-1c71-49d8-8d59-4c5e892c71a3" />
<br />
그후 data가 정상적으로 불러와져 합불조회 모달이 발생합니다

해서 useEffect의 조건에 `queryParams`를 제외하여 해결했습니다
