### PR TITLE
[hotfix] 모의성적 안내 모달 추가

### DIFF
--- a/apps/client/src/app/oneseo/calculate/page.tsx
+++ b/apps/client/src/app/oneseo/calculate/page.tsx
@@ -1,5 +1,8 @@
 import { CalculatePage } from 'client/pageContainer';
+import { getIsServerHealthy } from 'client/utils';
 
-export default function Calculate() {
-  return <CalculatePage />;
+export default async function Calculate() {
+  const isServerHealthy = await getIsServerHealthy();
+
+  return <CalculatePage isServerHealthy={isServerHealthy} />;
 }

--- a/apps/client/src/components/Header/index.tsx
+++ b/apps/client/src/components/Header/index.tsx
@@ -358,6 +358,7 @@ const Header = ({ isServerHealthy }: HeaderProps) => {
         { href: '/', label: '홈' },
         { href: '/guide', label: '원서 접수' },
         { href: '/faq', label: '자주 묻는 질문' },
+        { href: '/oneseo/calculate', label: '모의 성적 계산' },
         {
           href: '/introduce',
           label: '더모먼트',

--- a/apps/client/src/pageContainer/CalculatePage/index.tsx
+++ b/apps/client/src/pageContainer/CalculatePage/index.tsx
@@ -6,8 +6,20 @@ import { useState } from 'react';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { usePostMockScore } from 'api';
 import Image from 'next/image';
+import Link from 'next/link';
 import { useForm } from 'react-hook-form';
-import { Button, ScoreCalculateDialog, Step4Register, step4Schema } from 'shared';
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogContent,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  Button,
+  ScoreCalculateDialog,
+  Step4Register,
+  step4Schema,
+} from 'shared';
 import {
   GEDAchievementType,
   GraduationTypeValueEnum,
@@ -28,7 +40,11 @@ const graduationArray = [
   { text: '검정고시', value: GraduationTypeValueEnum.GED, img: '/images/ged.png' },
 ];
 
-const CalculatePage = () => {
+interface CalculateProps {
+  isServerHealthy: boolean;
+}
+
+const CalculatePage = ({ isServerHealthy }: CalculateProps) => {
   const step4UseForm = useForm<Step4FormType>({
     resolver: zodResolver(step4Schema),
     defaultValues: {
@@ -99,6 +115,19 @@ const CalculatePage = () => {
 
   return (
     <>
+      <AlertDialog open={!isServerHealthy}>
+        <AlertDialogContent className={cn('w-[400px]')}>
+          <AlertDialogHeader>
+            <AlertDialogTitle>모의성적 계산은 10월 13일부터 가능합니다.</AlertDialogTitle>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogAction>
+              <Link href={'/'}>확인</Link>
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+
       <ComputerRecommendedPage />
       {graduationType ? (
         <div className={cn('sm:flex', 'justify-center', 'rounded-[1.25rem]', 'hidden')}>


### PR DESCRIPTION
## 개요 💡

> 서버 상태에 따른 **모의성적 안내 모달** 추가 작업 진행했습니다.

## 작업내용 ⌨️

- 모의성적 안내 모달 추가
- `isServerHealthy` 가 아닐 경우, 헤더에 `'모의 성적 계산'` 링크 추가

## 화면
<img width="605" height="351" alt="image" src="https://github.com/user-attachments/assets/458651a4-5c8a-45ee-8ad5-cc8bfe07a70e" />

