### PR TITLE
[fix] 검정고시일 경우 출신중학교 셀에 경계 스타일 추가

### DIFF
--- a/apps/client/src/components/OneseoStatus/index.tsx
+++ b/apps/client/src/components/OneseoStatus/index.tsx
@@ -67,7 +67,10 @@ const OneseoStatus = ({ oneseo }: OneseoStatusType) => {
             출신중학교
           </td>
           {oneseo.privacyDetail.graduationType === 'GED' ? (
-            <td colSpan={2} className={cn('bg-slash', 'bg-contain', 'bg-no-repeat')} />
+            <td
+              colSpan={2}
+              className={cn('bg-slash', 'bg-contain', 'bg-no-repeat', 'border-r', 'border-black')}
+            />
           ) : (
             <td className={cn('border', 'border-t-0', 'border-black')} colSpan={2}>
               {oneseo.privacyDetail.schoolName}


### PR DESCRIPTION
## 개요 💡

> 기존에 검정고시의 경우, 출신 중학교 위치에 `bg-slash` 배경은 있었지만 테두리가 없어 UI가 어색하게 보였습니다. 
`border` 속성을 추가하여 해당 문제를 수정했습니다.

## 화면
[변경 전]
<img width="996" height="162" alt="image" src="https://github.com/user-attachments/assets/ee0dfd74-5647-4765-b3ab-0d8625cf0be0" />


[변경 후]
<img width="745" height="115" alt="image" src="https://github.com/user-attachments/assets/26c02616-9be1-49c6-a7c8-581f06a51f96" />


