### PR TITLE
[refactor] 회원가입 성공 후 쿼리 캐시 무효화 방식으로 개선

### DIFF
--- a/apps/client/src/pageContainer/SignUpPage/index.tsx
+++ b/apps/client/src/pageContainer/SignUpPage/index.tsx
@@ -2,8 +2,10 @@
 
 import { useEffect, useState } from 'react';
 
+import { useQueryClient } from '@tanstack/react-query';
+
 import { zodResolver } from '@hookform/resolvers/zod';
-import { useGetDuplicateMember, useGetMyAuthInfo, useGetMyMemberInfo } from 'api';
+import { memberQueryKeys, useGetDuplicateMember } from 'api';
 import { useRouter } from 'next/navigation';
 import { useForm, FormProvider } from 'react-hook-form';
 import { MemberRegisterType, SendCodeType, SexType } from 'types';
@@ -127,8 +129,7 @@ const SignUpPage = ({ isPastAnnouncement }: SignUpProps) => {
 
   const targetYear = new Date().getFullYear();
 
-  const { refetch: refetchGetMyAuthInfo } = useGetMyAuthInfo();
-  const { refetch: refetchGetMyMemberInfo } = useGetMyMemberInfo();
+  const queryClient = useQueryClient();
 
   const { refetch: checkDuplicateMember } = useGetDuplicateMember(phoneNumber, {
     enabled: false,
@@ -137,8 +138,8 @@ const SignUpPage = ({ isPastAnnouncement }: SignUpProps) => {
   const { mutate: mutateMemberRegister } = usePostMemberRegister({
     onError: () => setShowModal('error'),
     onSuccess: () => {
-      refetchGetMyAuthInfo();
-      refetchGetMyMemberInfo();
+      queryClient.invalidateQueries({ queryKey: memberQueryKeys.getMyAuthInfo() });
+      queryClient.invalidateQueries({ queryKey: memberQueryKeys.getMyMemberInfo() });
       setShowModal('success');
     },
   });


### PR DESCRIPTION
## 개요 💡

회원가입 성공 후에도 헤더에 '회원가입을 진행해주세요'라는 문구가 표시되는 문제가 있었습니다. 원인을 확인해 보니 useGetMyAuthInfo, useGetMyMemberInfo 훅에 staleTime이 설정되어 있어, refetch를 호출해도 이전에 불러온 데이터가 그대로 반환되는 것이었습니다. 이를 해결하기 위해 invalidateQueries를 사용해 staleTime과 관계없이 쿼리 데이터를 강제로 오래된(stale) 상태로 변경하는 방식으로 수정했습니다.

## 작업내용 ⌨️

- refetch 함수들을 queryClient.invalidateQueries로 변경