### PR TITLE
[fix]검정고시 step4 버튼 활성화 오류 수정

### DIFF
--- a/packages/shared/src/components/register/Step4Register/index.tsx
+++ b/packages/shared/src/components/register/Step4Register/index.tsx
@@ -294,7 +294,7 @@ const Step4Register = ({
                 placeholder="평균 점수 입력"
                 onChange={(e) => {
                   const value = e.target.value;
-                  const numericValue = isNaN(Number(value)) ? null : Number(value);
+                  const numericValue = isNaN(Number(value)) ? 0 : Number(value);
                   setValue('gedAvgScore', numericValue);
                 }}
               />


### PR DESCRIPTION
## 개요 💡

검정고시 step4 버튼이 잘못된 상황에서 활성화되는 오류를 수정했습니다

## 작업내용 ⌨️

#214 에서 step이동시 NaN이 출력되는 문제를 해결하기 위해 
```tsx
const numericValue = isNaN(Number(value)) ? null : Number(value);
```
문자를 입력하면 null이 반환되는 해당 구문이 추가되었습니다

하지만 스키마상으로 `nullable`로 처리되어있어 위 로직으로 null이 반환되는 순간 버튼이 활성화 처리 됩니다

이를 해결하기 위해 반환 값을 null이 아닌 `0`으로 수정했습니다