### PR TITLE
[fix] GED 평균 점수 입력란 숫자 처리 개선 

### DIFF
--- a/packages/shared/src/components/register/Step4Register/index.tsx
+++ b/packages/shared/src/components/register/Step4Register/index.tsx
@@ -292,7 +292,7 @@ const Step4Register = ({
                 {...register('gedAvgScore', {
                   setValueAs: (v) => {
                     const num = Number(v);
-                    return !num ? undefined : num; // 0 또는 NaN이면 undefined로 처리
+                    return !num ? undefined : num;
                   },
                 })}
                 placeholder="평균 점수 입력"

--- a/packages/shared/src/components/register/Step4Register/index.tsx
+++ b/packages/shared/src/components/register/Step4Register/index.tsx
@@ -288,14 +288,14 @@ const Step4Register = ({
                 검정고시 평균 점수 <span className={cn('text-red-600')}>*</span>
               </p>
               <Input
+                type="text"
                 {...register('gedAvgScore', {
-                  valueAsNumber: true,
+                  setValueAs: (v) => (v === '' ? undefined : Number(v)),
                 })}
                 placeholder="평균 점수 입력"
-                onChange={(e) => {
-                  const value = e.target.value;
-                  const numericValue = isNaN(Number(value)) ? null : Number(value);
-                  setValue('gedAvgScore', numericValue);
+                onInput={(e: React.FormEvent<HTMLInputElement>) => {
+                  const input = e.currentTarget;
+                  input.value = input.value.replace(/[^0-9]/g, '');
                 }}
               />
             </div>

--- a/packages/shared/src/components/register/Step4Register/index.tsx
+++ b/packages/shared/src/components/register/Step4Register/index.tsx
@@ -290,7 +290,10 @@ const Step4Register = ({
               <Input
                 type="text"
                 {...register('gedAvgScore', {
-                  setValueAs: (v) => (v === '' ? undefined : Number(v)),
+                  setValueAs: (v) => {
+                    const num = Number(v);
+                    return !num ? undefined : num; // 0 또는 NaN이면 undefined로 처리
+                  },
                 })}
                 placeholder="평균 점수 입력"
                 onInput={(e: React.FormEvent<HTMLInputElement>) => {


### PR DESCRIPTION
## 개요 💡

> GED 평균 점수 입력란 숫자 처리 개선을 위해  `0/NaN` 방지 및 한글/영어 입력 차단 작업 진행했습니다.

## 작업내용 ⌨️

* GED 평균 점수 `Input`에서 한글/영어 입력을 실시간으로 제거하도록 수정
* 빈 문자열, 0 또는 잘못된 값(NaN) 입력 시 내부 state가 `undefined`가 되도록 `setValueAs` 처리
* 기존 방식에서는 화면에 입력되지 않아도 내부 값이 남아 zod 유효성 검사가 꼬이는 문제 발생
* 새 방식은 화면과 내부 상태가 항상 일치하도록 개선하여, GED `Input`이 빈값으로 안전하게 유지되도록 수정
