### PR TITLE
[ci/cd] stage env추가

### DIFF
--- a/.github/workflows/stage-cd.yml
+++ b/.github/workflows/stage-cd.yml
@@ -9,6 +9,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     env:
+      NEXT_PUBLIC_STAGE: ${{ secrets.NEXT_PUBLIC_STAGE }}
       NEXT_PUBLIC_API_BASE_URL: ${{ secrets.NEXT_PUBLIC_STAGE_API_BASE_URL }}
       NEXT_PUBLIC_CHANNEL_IO_KEY: ${{ secrets.NEXT_PUBLIC_CHANNEL_IO_KEY }}
       NEXT_PUBLIC_IMAGE_URL: ${{ secrets.NEXT_PUBLIC_IMAGE_URL }}
@@ -49,6 +50,7 @@ jobs:
       - name: Docker Client build
         run: |
           docker build \
+          --build-arg NEXT_PUBLIC_STAGE=${{ secrets.NEXT_PUBLIC_STAGE }} \
           --build-arg NEXT_PUBLIC_API_BASE_URL=${{ secrets.NEXT_PUBLIC_STAGE_API_BASE_URL }} \
           --build-arg NEXT_PUBLIC_CHANNEL_IO_KEY=${{ secrets.NEXT_PUBLIC_CHANNEL_IO_KEY }} \
           --build-arg NEXT_PUBLIC_IMAGE_URL=${{ secrets.NEXT_PUBLIC_IMAGE_URL }} \
@@ -103,6 +105,7 @@ jobs:
             docker run -d \
               --name hello-stage-client \
               -p 3004:3000 \
+              -e NEXT_PUBLIC_STAGE=${{ secrets.NEXT_PUBLIC_STAGE }} \
               -e NEXT_PUBLIC_API_BASE_URL=${{ secrets.NEXT_PUBLIC_STAGE_API_BASE_URL }} \
               -e NEXT_PUBLIC_CHANNEL_IO_KEY=${{ secrets.NEXT_PUBLIC_CHANNEL_IO_KEY }} \
               -e NEXT_PUBLIC_IMAGE_URL=${{ secrets.NEXT_PUBLIC_IMAGE_URL }} \

--- a/.github/workflows/stage-ci.yml
+++ b/.github/workflows/stage-ci.yml
@@ -9,6 +9,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     env:
+      NEXT_PUBLIC_STAGE: ${{ secrets.NEXT_PUBLIC_STAGE }}
       NEXT_PUBLIC_API_BASE_URL: ${{ secrets.NEXT_PUBLIC_STAGE_API_BASE_URL }}
       NEXT_PUBLIC_CHANNEL_IO_KEY: ${{ secrets.NEXT_PUBLIC_CHANNEL_IO_KEY }}
       NEXT_PUBLIC_IMAGE_URL: ${{ secrets.NEXT_PUBLIC_IMAGE_URL }}
@@ -39,6 +40,7 @@ jobs:
       - name: Docker Client build
         run: |
           docker build \
+          --build-arg NEXT_PUBLIC_STAGE=${{ secrets.NEXT_PUBLIC_STAGE }} \
           --build-arg NEXT_PUBLIC_API_BASE_URL=${{ secrets.NEXT_PUBLIC_STAGE_API_BASE_URL }} \
           --build-arg NEXT_PUBLIC_CHANNEL_IO_KEY=${{ secrets.NEXT_PUBLIC_CHANNEL_IO_KEY }} \
           --build-arg NEXT_PUBLIC_IMAGE_URL=${{ secrets.NEXT_PUBLIC_IMAGE_URL }} \


### PR DESCRIPTION
## 개요 💡

`NEXT_PUBLIC_STAGE`를 추가했습니다

## 작업내용 ⌨️

stage환경이 검색엔진에 노출되는 현상이 발생했습니다
```tsx
{process.env.NEXT_PUBLIC_STAGE === 'stage' && (
  <>
    <meta name="robots" content="noindex, nofollow" />
    <meta name="msvalidate.01" content="14471419A8701E4145F89E3ADCCFB1D6" />
  </>
)}
```
해당부분에서 `NEXT_PUBLIC_STAGE`관련 설정이 정상적으로 적용되지 않는 것 같아, workflows에 `NEXT_PUBLIC_STAGE`를 추가했습니다

## 관련 issue 🤯

repogitory secrets에 `NEXT_PUBLIC_STAGE` 추가
