### PR TITLE
[feat] 엑셀 업로드

### DIFF
--- a/apps/admin/src/app/provider.tsx
+++ b/apps/admin/src/app/provider.tsx
@@ -4,10 +4,18 @@ import { PropsWithChildren } from 'react';
 
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 
+import { ToastContainer } from 'react-toastify';
+import 'react-toastify/dist/ReactToastify.css';
+
 const Provider = ({ children }: PropsWithChildren) => {
   const queryClient = new QueryClient();
 
-  return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
+  return (
+    <QueryClientProvider client={queryClient}>
+      {children}
+      <ToastContainer />
+    </QueryClientProvider>
+  );
 };
 
 export default Provider;

--- a/apps/admin/src/app/provider.tsx
+++ b/apps/admin/src/app/provider.tsx
@@ -5,7 +5,6 @@ import { PropsWithChildren } from 'react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 
 import { ToastContainer } from 'react-toastify';
-import 'react-toastify/dist/ReactToastify.css';
 
 const Provider = ({ children }: PropsWithChildren) => {
   const queryClient = new QueryClient();

--- a/apps/admin/src/assets/icons/FilterBar/UploadIcon.tsx
+++ b/apps/admin/src/assets/icons/FilterBar/UploadIcon.tsx
@@ -1,0 +1,29 @@
+const UploadIcon = () => {
+  return (
+    <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16" fill="none">
+      <path
+        d="M14 10V12.6667C14 13.0203 13.8595 13.3594 13.6095 13.6095C13.3594 13.8595 13.0203 14 12.6667 14H3.33333C2.97971 14 2.64057 13.8595 2.39052 13.6095C2.14048 13.3594 2 13.0203 2 12.6667V10"
+        stroke="#1E293B"
+        strokeWidth="1.2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+      <path
+        d="M11.3337 5.33333L8.00033 2L4.66699 5.33333"
+        stroke="#1E293B"
+        strokeWidth="1.2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+      <path
+        d="M8 2V10"
+        stroke="black"
+        strokeWidth="1.2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </svg>
+  );
+};
+
+export default UploadIcon;

--- a/apps/admin/src/assets/icons/index.ts
+++ b/apps/admin/src/assets/icons/index.ts
@@ -6,3 +6,4 @@ export { default as SearchIcon } from './FilterBar/SearchIcon';
 export { default as FileIcon } from './FilterBar/FileIcon';
 export { default as CloverIcon } from './FilterBar/CloverIcon';
 export { default as MedalIcon } from './FilterBar/MedalIcon';
+export { default as UploadIcon } from './FilterBar/UploadIcon';

--- a/apps/admin/src/components/FilterBar/index.tsx
+++ b/apps/admin/src/components/FilterBar/index.tsx
@@ -1,10 +1,10 @@
 'use client';
 
-import { useState } from 'react';
+import { useState, useRef } from 'react';
 
-import { useGetOperation, usePostFirstResult, usePostSecondResult } from 'api';
+import { useGetOperation, usePostExcel, usePostFirstResult, usePostSecondResult } from 'api';
 
-import { SearchIcon, FileIcon, CloverIcon, MedalIcon } from 'admin/assets';
+import { SearchIcon, FileIcon, CloverIcon, MedalIcon, UploadIcon } from 'admin/assets';
 
 import { PrintIcon } from 'shared/assets';
 import {
@@ -52,6 +52,7 @@ const FilterBar = ({
 }: FilterBarProps) => {
   const [showFirstModal, setShowFirstModal] = useState<boolean>(false);
   const [showSecondModal, setShowSecondModal] = useState<boolean>(false);
+  const fileInputRef = useRef<HTMLInputElement>(null);
 
   const { data: operationData, refetch: operationRefetch } = useGetOperation();
 
@@ -63,6 +64,13 @@ const FilterBar = ({
   });
 
   const { mutate: postSecondResult } = usePostSecondResult({
+    onSuccess: () => {
+      operationRefetch();
+    },
+    onError: () => {},
+  });
+
+  const { mutate: postExcel } = usePostExcel({
     onSuccess: () => {
       operationRefetch();
     },
@@ -96,8 +104,32 @@ const FilterBar = ({
     window.open('/print');
   };
 
+  const uploadExcel = () => {
+    fileInputRef.current?.click();
+  };
+
+  const handleExcelFileChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const file = event.target.files?.[0];
+
+    if (file) {
+      const formData = new FormData();
+      formData.append('file', file);
+      postExcel(formData);
+    }
+    if (fileInputRef.current) {
+      fileInputRef.current.value = '';
+    }
+  };
+
   return (
     <>
+      <input
+        ref={fileInputRef}
+        type="file"
+        accept=".xlsx"
+        onChange={handleExcelFileChange}
+        className={cn('hidden')}
+      />
       <div className={cn('flex', 'items-center', 'justify-between', 'w-full')}>
         <div className={cn('flex', 'items-center')}>
           <Input
@@ -181,6 +213,14 @@ const FilterBar = ({
           >
             <FileIcon />
             Excel 다운
+          </Button>
+          <Button
+            onClick={uploadExcel}
+            variant="outline"
+            className={cn('border-slate-900', 'gap-2', 'hover:bg-slate-200')}
+          >
+            <UploadIcon />
+            Excel 업로드
           </Button>
         </div>
       </div>

--- a/apps/admin/src/components/FilterBar/index.tsx
+++ b/apps/admin/src/components/FilterBar/index.tsx
@@ -2,7 +2,10 @@
 
 import { useState, useRef } from 'react';
 
+import type { AxiosError } from 'axios';
+
 import { useGetOperation, usePostExcel, usePostFirstResult, usePostSecondResult } from 'api';
+import { toast } from 'react-toastify';
 
 import { SearchIcon, FileIcon, CloverIcon, MedalIcon, UploadIcon } from 'admin/assets';
 
@@ -73,8 +76,13 @@ const FilterBar = ({
   const { mutate: postExcel } = usePostExcel({
     onSuccess: () => {
       operationRefetch();
+      toast.success('성공했습니다!');
     },
-    onError: () => {},
+    onError: (error) => {
+      const axiosError = error as AxiosError<{ message?: string }>;
+      const serverMessage = axiosError.response?.data?.message;
+      toast.error(serverMessage ?? '오류가 발생했습니다.');
+    },
   });
 
   const handleSubmittedChange = (value: string) => {

--- a/packages/api/src/hooks/api/oneseo/index.ts
+++ b/packages/api/src/hooks/api/oneseo/index.ts
@@ -11,3 +11,4 @@ export * from './useGetMyOneseo';
 export * from './usePostImage';
 export * from './usePatchAgreeDocStatus';
 export * from './useGetEditability';
+export * from './usePostExcel';

--- a/packages/api/src/hooks/api/oneseo/usePostExcel.ts
+++ b/packages/api/src/hooks/api/oneseo/usePostExcel.ts
@@ -1,0 +1,16 @@
+import { useMutation, UseMutationOptions } from '@tanstack/react-query';
+
+import { AxiosError } from 'axios';
+
+import { oneseoQueryKeys, oneseoUrl, post } from 'api/libs';
+
+export const usePostExcel = (options?: UseMutationOptions<unknown, AxiosError, FormData>) =>
+  useMutation({
+    mutationKey: oneseoQueryKeys.postExcel(),
+    mutationFn: (formData: FormData) => {
+      return post(oneseoUrl.postExcel(), formData, {
+        headers: { 'Content-Type': 'multipart/form-data' },
+      });
+    },
+    ...options,
+  });

--- a/packages/api/src/libs/queryKeys.ts
+++ b/packages/api/src/libs/queryKeys.ts
@@ -25,6 +25,7 @@ export const oneseoQueryKeys = {
   getAdmissionTickets: () => ['tickets'],
   getMyOneseo: () => ['get', 'my', 'oneseo'],
   getEditability: () => ['get', 'my', 'editability'],
+  postExcel: () => ['post', 'excel'],
 } as const;
 
 export const memberQueryKeys = {

--- a/packages/api/src/libs/requestUrlController.ts
+++ b/packages/api/src/libs/requestUrlController.ts
@@ -41,6 +41,7 @@ export const oneseoUrl = {
   patchInterviewScore: (memberId: number) => `/oneseo/v3/interview-score/${memberId}`,
   getAdmissionTickets: () => '/oneseo/v3/admission-tickets',
   getEditability: () => '/oneseo/v3/editability',
+  postExcel: () => '/oneseo/v3/excel',
 } as const;
 
 export const memberUrl = {


### PR DESCRIPTION
## 개요 💡

어드민 페이지에서 엑셀 업로드 기능 추가

## 작업내용 ⌨️

어드민 페이지에서 수험번호, 역검점수, 면접점수를 하나의 엑셀파일로 업로드하는 기능을 작업했습니다

엑셀의 예시입니다
<img width="235" height="104" alt="image" src="https://github.com/user-attachments/assets/f3fe7aed-374b-40f9-b839-e6d778418891" />
