### PR TITLE
[style] Header 간격 및 드롭다운 메뉴 위치 조정

### DIFF
--- a/apps/client/src/components/Header/index.tsx
+++ b/apps/client/src/components/Header/index.tsx
@@ -75,7 +75,7 @@ const PCNavigation = ({ links, isRegisterPath }: NavProps) => {
     return (
       <nav
         className={cn(
-          'gap-[2.75rem]',
+          'gap-[2.5rem]',
           'hidden',
           'md:flex',
           'justify-between',
@@ -96,7 +96,7 @@ const PCNavigation = ({ links, isRegisterPath }: NavProps) => {
   return (
     <nav
       className={cn(
-        'gap-[2.75rem]',
+        'gap-[2.5rem]',
         'hidden',
         'md:flex',
         'justify-between',
@@ -232,10 +232,10 @@ const DropdownMenu = ({
         className={cn(
           'absolute',
           'top-full',
-          'left-[-17.5%]',
+          'left-[-40%]',
           'mt-2',
           'flex',
-          'w-auto',
+          'w-[10rem]',
           'flex-col',
           'items-start',
           'shadow-sm',
@@ -262,10 +262,10 @@ const DropdownMenu = ({
       className={cn(
         'absolute',
         'top-full',
-        'left-[-17.5%]',
+        'left-[-40%]',
         'mt-2',
         'flex',
-        'w-fit',
+        'w-[10rem]',
         'flex-col',
         'items-start',
         'shadow-sm',


### PR DESCRIPTION
## 개요 💡

> header 반응형 수정 작업 진행했습니다.

## 작업내용 ⌨️

> [257](https://github.com/themoment-team/hellogsm-front-24/pull/257) 해당 PR에서 디자인과 통일하기 위해 `'w-[10rem]'` 속성을 삭제하자 '내 정보 페이지' 텍스트가 줄바꿈되는 현상이 발생했습니다.
이를 해결하기 위해 `gap` 사이즈를 줄이고, `DropdownMenu`의 위치를 조정했습니다.

