### PR TITLE
[fix] 역량검사 필드명 통일화

### DIFF
--- a/apps/admin/src/components/ApplicantTR/index.stories.tsx
+++ b/apps/admin/src/components/ApplicantTR/index.stories.tsx
@@ -55,7 +55,7 @@ const MockData: ApplicationTRProps = {
   guardianPhoneNumber: '010 1234 5678',
   schoolTeacherPhoneNumber: '010 1234 5678',
   firstTestPassYn: 'YES',
-  aptitudeEvaluationScore: 100,
+  competencyEvaluationScore: 100,
   interviewScore: 100,
   secondTestPassYn: 'YES',
   oneseoRefetch: oneseoFakeRefetch,

--- a/apps/admin/src/components/ApplicantTR/index.tsx
+++ b/apps/admin/src/components/ApplicantTR/index.tsx
@@ -52,7 +52,7 @@ interface ApplicationTRProps extends OneseoType {
 
 const ApplicantTR = ({
   oneseoRefetch,
-  aptitudeEvaluationScore,
+  competencyEvaluationScore,
   firstTestPassYn,
   guardianPhoneNumber,
   interviewScore,
@@ -124,7 +124,7 @@ const ApplicantTR = ({
   const is역량검사처리기간 = checkIsPassedDate(역량검사처리시작일자);
   const is심층면접처리기간 = checkIsPassedDate(심층면접처리시작일자);
 
-  const formatted역량검사점수 = formatScore(String(aptitudeEvaluationScore ?? ''));
+  const formatted역량검사점수 = formatScore(String(competencyEvaluationScore ?? ''));
   const formatted심층면접점수 = formatScore(String(interviewScore ?? ''));
 
   const { control, watch, setValue } = useForm({
@@ -165,7 +165,7 @@ const ApplicantTR = ({
 
     if (역량검사점수 < 0 || 역량검사점수 > 100 || isNaN(역량검사점수)) return;
 
-    patchAptitudeScore({ aptitudeEvaluationScore: 역량검사점수 });
+    patchAptitudeScore({ competencyEvaluationScore: 역량검사점수 });
   };
 
   const handleInterviewScore = () => {

--- a/packages/api/src/hooks/api/oneseo/usePatchAptitudeScore.ts
+++ b/packages/api/src/hooks/api/oneseo/usePatchAptitudeScore.ts
@@ -6,11 +6,11 @@ import { oneseoQueryKeys, oneseoUrl, patch } from 'api/libs';
 
 export const usePatchAptitudeScore = (
   memberId: number,
-  options?: UseMutationOptions<unknown, AxiosError, { aptitudeEvaluationScore: number }>,
+  options?: UseMutationOptions<unknown, AxiosError, { competencyEvaluationScore: number }>,
 ) =>
   useMutation({
     mutationKey: oneseoQueryKeys.patchAptitudeScore(memberId),
-    mutationFn: (aptitudeEvaluationScore) =>
-      patch(oneseoUrl.patchAptitudeScore(memberId), aptitudeEvaluationScore),
+    mutationFn: (competencyEvaluationScore) =>
+      patch(oneseoUrl.patchAptitudeScore(memberId), competencyEvaluationScore),
     ...options,
   });

--- a/packages/types/src/oneseo.ts
+++ b/packages/types/src/oneseo.ts
@@ -192,7 +192,7 @@ export interface OneseoType {
   guardianPhoneNumber: string;
   schoolTeacherPhoneNumber: string;
   firstTestPassYn: YesNo | null;
-  aptitudeEvaluationScore: number | null;
+  competencyEvaluationScore: number | null;
   interviewScore: number | null;
   secondTestPassYn: YesNo | null;
 }


### PR DESCRIPTION
## 개요 💡

역량검사 필드명 통일화

## 작업내용 ⌨️

올해 직무적성소양평가가 역랑검사로 전환되었습니다
그에따라 서버단에서는 `aptitudeEvaluationScore`이던 값을 `competencyEvaluationScore`로 바꿨습니다

하지만 프론트단에서는 바꾸지 않아 값이 표시되지 않는 문제가 발생했습니다

해당 부분을 수정했습니다


