### PR TITLE
[fix] 로그인 콜백 페이지에서 성공 토스트 제거

### DIFF
--- a/apps/client/src/pageContainer/CallbackPage/index.tsx
+++ b/apps/client/src/pageContainer/CallbackPage/index.tsx
@@ -23,8 +23,6 @@ const CallbackPage = ({ code, provider }: { code: string; provider: string }) =>
     const clientBaseUrl = isStage ? 'https://www.stage.hellogsm.kr' : 'https://www.hellogsm.kr';
     const nextUrl = provider === 'admin' ? `${clientBaseUrl}/?isAdmin=true` : clientBaseUrl;
     router.replace(nextUrl);
-
-    toast.success('로그인에 성공했습니다.');
   };
 
   const handleLoginError = () => {


### PR DESCRIPTION
## 개요 💡

OAuth 플로우 변경 전처럼 로그인 시 성공 토스트를 제거했습니다.

## 작업내용 ⌨️

- 로그인 콜백 페이지에서 성공 토스트 제거