### PR TITLE
[fix] 리다이렉트 방식을 router.push에서 router.replace로 변경

### DIFF
--- a/apps/client/src/pageContainer/SignUpPage/index.tsx
+++ b/apps/client/src/pageContainer/SignUpPage/index.tsx
@@ -475,7 +475,7 @@ const SignUpPage = ({ isPastAnnouncement }: SignUpProps) => {
               onClick={() => {
                 setShowModal('');
                 if (showModal === 'success') {
-                  router.push('/');
+                  router.replace('/');
                   router.refresh();
                 }
               }}


### PR DESCRIPTION
## 개요 💡

회원가입 성공 시 리다이렉트 방식을 router.push에서 router.replace로 변경했습니다.

## 작업내용 ⌨️

리다이렉트 방식을 router.push에서 router.replace로 변경

## 관련 issue 🤯

https://github.com/themoment-team/hellogsm-front-25/pull/283 해당 PR에서 router.push와 router.refresh를 사용하는 방식으로 변경했지만, 결과적으로 실패하여 router.push를 router.replace로 수정했습니다. 만약 이 방법도 제대로 동작하지 않는다면, window.location.href = '/'를 사용해 페이지를 완전히 새로고침하는 방식으로 변경해야 할 것 같습니다. 이 경우 단일 페이지 애플리케이션(SPA)의 장점을 일부 포기하게 되지만, 데이터 정합성을 확실히 보장할 수 있습니다.

로컬에서는 정상적으로 동작하지만, stage 환경에서는 제대로 작동하지 않아 같은 내용으로 여러 번 pr 올리게 된 점 양해 부탁드립니다.