### PR TITLE
[style] 예체능 성적 학년 표기를 일반교과 성적 표기와 통일

### DIFF
--- a/apps/client/src/components/PrintPage/ArtsPhysicalTable/index.tsx
+++ b/apps/client/src/components/PrintPage/ArtsPhysicalTable/index.tsx
@@ -18,6 +18,15 @@ const ArtsPhysicalTable = ({ oneseo }: OneseoStatusType) => {
     return false;
   });
 
+  const semesterLabelMap: Record<string, string> = {
+    '1-1': '1학년 1학기',
+    '1-2': '1학년 2학기',
+    '2-1': '2학년 1학기',
+    '2-2': '2학년 2학기',
+    '3-1': '3학년 1학기',
+    '3-2': '3학년 2학기',
+  };
+
   return (
     <table className={cn('w-full', 'border', 'border-black', 'text-center')}>
       <thead>
@@ -34,7 +43,7 @@ const ArtsPhysicalTable = ({ oneseo }: OneseoStatusType) => {
               key={semester}
               className={cn('h-[2.2vh]', 'border', 'border-black', 'bg-gray-200', 'p-[0.2vh]')}
             >
-              {semester}
+              {semesterLabelMap[semester] ?? semester}
             </td>
           ))}
         </tr>


### PR DESCRIPTION
## 개요 💡

> 예체능 성적 학년 표기를 일반교과 성적 표기와 통일 시켰습니다.

## 화면 ⌨️
### 변경 전
<img width="408" height="316" alt="image" src="https://github.com/user-attachments/assets/85af103c-6c91-4e34-b8fe-4e7c9514544a" />

### 변경 후 
<img width="430" height="275" alt="image" src="https://github.com/user-attachments/assets/bd6b878d-513d-43ec-8a0c-a8846395015f" />
