### PR TITLE
[fix] 인쇄 시 불필요한 페이지 출력 문제 해결

### DIFF
--- a/apps/client/src/components/PrintPage/ApplicationForm/index.tsx
+++ b/apps/client/src/components/PrintPage/ApplicationForm/index.tsx
@@ -22,24 +22,17 @@ const ApplicationForm = ({ oneseo }: OneseoStatusType) => {
         'bg-white',
         'p-2',
         'text-[1vh]',
+
+        'print:w-[210mm]',
+        'print:h-[297mm]',
+        'print:flex',
+        'print:items-center',
+        'print:justify-center',
+        'print:p-0',
+        'print:m-0',
       )}
     >
-      <div
-        className={cn(
-          'relative',
-          'z-[2]',
-          'w-[63vh]',
-          'py-20',
-
-          'print:w-[210mm]',
-          'print:h-[297mm]',
-          'print:flex',
-          'print:items-center',
-          'print:justify-center',
-          'print:p-0',
-          'print:m-0',
-        )}
-      >
+      <div className={cn('relative', 'z-[2]', 'w-[63vh]', 'py-20')}>
         <div className={cn('relative', 'z-[2]', 'w-[63vh]')}>
           <div
             id="sample"


### PR DESCRIPTION
## 개요 💡

> 인쇄 시 불필요하게 빈 페이지가 출력되던 문제를 해결

## 작업내용 ⌨️

> print 관련 스타일(`print:w-[210mm]`, `print:h-[297mm]` 등)을 최상위 컨테이너로 이동


