### PR TITLE
fix: 모노레포 standalone 빌드를 위한 outputFileTracingRoot 추가

### DIFF
--- a/apps/admin/next.config.mjs
+++ b/apps/admin/next.config.mjs
@@ -1,6 +1,11 @@
 /** @type {import('next').NextConfig} */
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 const nextConfig = {
+  outputFileTracingRoot: path.join(__dirname, '../../'),
   images: {
     remotePatterns: [
       {

--- a/apps/admin/next.config.mjs
+++ b/apps/admin/next.config.mjs
@@ -5,7 +5,9 @@ import { fileURLToPath } from 'url';
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 const nextConfig = {
-  outputFileTracingRoot: path.join(__dirname, '../../'),
+  experimental: {
+    outputFileTracingRoot: path.join(__dirname, '../../'),
+  },
   images: {
     remotePatterns: [
       {

--- a/apps/client/next.config.mjs
+++ b/apps/client/next.config.mjs
@@ -5,7 +5,9 @@ import { fileURLToPath } from 'url';
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 const nextConfig = {
-  outputFileTracingRoot: path.join(__dirname, '../../'),
+  experimental: {
+    outputFileTracingRoot: path.join(__dirname, '../../'),
+  },
   images: {
     domains: ['github.com'],
     remotePatterns: [

--- a/apps/client/next.config.mjs
+++ b/apps/client/next.config.mjs
@@ -1,6 +1,11 @@
 /** @type {import('next').NextConfig} */
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 const nextConfig = {
+  outputFileTracingRoot: path.join(__dirname, '../../'),
   images: {
     domains: ['github.com'],
     remotePatterns: [


### PR DESCRIPTION
## 개요 💡

모노레포 환경에서 Next.js standalone 빌드 시 컨테이너가 실행되지 않는 문제를 수정합니다.

## 작업내용 ⌨️

- `apps/client/next.config.mjs`, `apps/admin/next.config.mjs`에 `outputFileTracingRoot` 옵션 추가
- 의존성 트레이싱 기준을 모노레포 루트로 설정하여 standalone 빌드 결과물에 `next` 모듈이 정상 포함되도록 수정