### PR TITLE
[feat] 학생 생년월일 수정 기능 추가

### DIFF
--- a/apps/admin/src/app/edit/[memberId]/page.tsx
+++ b/apps/admin/src/app/edit/[memberId]/page.tsx
@@ -5,7 +5,6 @@ import { ComputerRecommendedPage, StepWrapper } from '@repo/ui/components';
 
 import { getOneseoByMemberId } from '@/app/apis';
 
-
 interface EditProps {
   params: { memberId: string };
   searchParams?: { [key: string]: string | undefined };

--- a/apps/admin/src/components/ApplicantTH/index.tsx
+++ b/apps/admin/src/components/ApplicantTH/index.tsx
@@ -7,7 +7,6 @@ import { cn } from '@repo/utils';
 
 import { QuestionMark } from '@/assets';
 
-
 const ApplicantTH = () => {
   const defaultStyle = cn('font-semibold', 'text-zinc-500');
 

--- a/apps/admin/src/components/ApplicantTR/index.tsx
+++ b/apps/admin/src/components/ApplicantTR/index.tsx
@@ -1,6 +1,5 @@
 'use client';
 
-
 import { QueryObserverResult, RefetchOptions } from '@tanstack/react-query';
 import { useRouter } from 'next/navigation';
 import { useEffect, useState } from 'react';

--- a/apps/admin/src/components/FilterBar/index.tsx
+++ b/apps/admin/src/components/FilterBar/index.tsx
@@ -24,7 +24,6 @@ import { cn } from '@repo/utils';
 
 import { CloverIcon, FileIcon, MedalIcon, SearchIcon, UploadIcon } from '@/assets';
 
-
 interface FilterBarProps {
   keyword: string;
   setKeyword: React.Dispatch<React.SetStateAction<string>>;

--- a/apps/admin/src/components/SideMenu/index.tsx
+++ b/apps/admin/src/components/SideMenu/index.tsx
@@ -9,7 +9,6 @@ import { cn } from '@repo/utils';
 
 import { ChevronsLeft, Exit, Puzzle } from '@/assets';
 
-
 const Item = ({ children }: PropsWithChildren) => (
   <div
     className={cn(

--- a/apps/admin/src/components/TextField/index.tsx
+++ b/apps/admin/src/components/TextField/index.tsx
@@ -16,7 +16,7 @@ const TextField = React.forwardRef<HTMLInputElement, React.InputHTMLAttributes<H
           'rounded-md',
           'focus: outline-slate-700',
           'text-zinc-900',
-          'border-input bg-background ring-offset-background placeholder:text-muted-foreground border px-3 py-1.5 text-sm file:border-0 file:bg-transparent file:text-sm file:font-medium disabled:cursor-not-allowed disabled:opacity-50',
+          'border border-input bg-background px-3 py-1.5 text-sm ring-offset-background file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-muted-foreground disabled:cursor-not-allowed disabled:opacity-50',
           className,
         )}
         ref={ref}

--- a/apps/admin/src/pageContainer/MainPage/index.tsx
+++ b/apps/admin/src/pageContainer/MainPage/index.tsx
@@ -17,7 +17,6 @@ import { cn } from '@repo/utils';
 
 import { ApplicantTH, ApplicantTR, FilterBar, SideMenu } from '@/components';
 
-
 interface MainPageProps {
   initialData: OneseoListType | undefined;
   isAfterFirstResults: boolean;
@@ -95,7 +94,7 @@ const MainPage = ({
     <main
       className={cn([
         isOpen && 'ml-60',
-        isOpen ? 'px-10' : 'pr-10 pl-20',
+        isOpen ? 'px-10' : 'pl-20 pr-10',
         'pt-[60px]',
         'pb-8',
         'bg-white',

--- a/apps/client/src/components/PrintPage/ConfirmationTable/index.tsx
+++ b/apps/client/src/components/PrintPage/ConfirmationTable/index.tsx
@@ -47,7 +47,7 @@ const ConfirmationTable = ({ oneseo }: OneseoStatusType) => {
               {oneseo.privacyDetail.graduationType === 'CANDIDATE' && (
                 <>
                   {oneseo.privacyDetail.schoolTeacherName}
-                  <span className="absolute top-1/2 right-1 -translate-y-1/2">(인)</span>
+                  <span className="absolute right-1 top-1/2 -translate-y-1/2">(인)</span>
                 </>
               )}
             </td>
@@ -66,7 +66,7 @@ const ConfirmationTable = ({ oneseo }: OneseoStatusType) => {
               )}
             >
               {oneseo.privacyDetail.name}
-              <span className="absolute top-1/2 right-1 -translate-y-1/2">(인)</span>
+              <span className="absolute right-1 top-1/2 -translate-y-1/2">(인)</span>
             </td>
           </tr>
         </tbody>

--- a/apps/client/src/components/PrintPage/ConfirmationTable/index.tsx
+++ b/apps/client/src/components/PrintPage/ConfirmationTable/index.tsx
@@ -92,7 +92,7 @@ const ConfirmationTable = ({ oneseo }: OneseoStatusType) => {
                 'w-[50%]',
                 'text-center',
               )}
-              rowSpan={2}
+              rowSpan={3}
             >
               광주소프트웨어마이스터고 접수자 확인
             </td>
@@ -104,6 +104,12 @@ const ConfirmationTable = ({ oneseo }: OneseoStatusType) => {
           <tr>
             <td className={cn('border', 'border-black', 'bg-gray-200', 'p-[0.3vh]', 'text-center')}>
               2차
+            </td>
+            <td className={cn('border', 'border-black', 'p-[0.3vh]', 'text-right')}>(인)</td>
+          </tr>
+          <tr>
+            <td className={cn('border', 'border-black', 'bg-gray-200', 'p-[0.3vh]', 'text-center')}>
+              3차
             </td>
             <td className={cn('border', 'border-black', 'p-[0.3vh]', 'text-right')}>(인)</td>
           </tr>

--- a/apps/client/src/components/PrintPage/PersonalInfoTable/index.tsx
+++ b/apps/client/src/components/PrintPage/PersonalInfoTable/index.tsx
@@ -91,7 +91,7 @@ const PersonalInfoTable = ({ oneseo }: OneseoStatusType) => {
             {oneseo.privacyDetail.graduationType === 'CANDIDATE' && (
               <>
                 {oneseo.privacyDetail.schoolTeacherName}
-                <span className="absolute top-1/2 right-1 -translate-y-1/2">(인)</span>
+                <span className="absolute right-1 top-1/2 -translate-y-1/2">(인)</span>
               </>
             )}
           </td>

--- a/packages/api/src/hooks/oneseo/index.ts
+++ b/packages/api/src/hooks/oneseo/index.ts
@@ -5,6 +5,7 @@ export * from './useGetOneseoList';
 export * from './usePatchAgreeDocStatus';
 export * from './usePatchArrivedStatus';
 export * from './usePatchPersonalInfo';
+export * from './usePatchPersonalInfoByMemberId';
 export * from './usePatchCompetencyScore';
 export * from './usePatchInterviewScore';
 export * from './usePostExcel';

--- a/packages/api/src/hooks/oneseo/index.ts
+++ b/packages/api/src/hooks/oneseo/index.ts
@@ -4,6 +4,7 @@ export * from './useGetMyOneseo';
 export * from './useGetOneseoList';
 export * from './usePatchAgreeDocStatus';
 export * from './usePatchArrivedStatus';
+export * from './usePatchPersonalInfo';
 export * from './usePatchCompetencyScore';
 export * from './usePatchInterviewScore';
 export * from './usePostExcel';

--- a/packages/api/src/hooks/oneseo/usePatchPersonalInfo.ts
+++ b/packages/api/src/hooks/oneseo/usePatchPersonalInfo.ts
@@ -1,0 +1,15 @@
+import { useMutation, UseMutationOptions } from '@tanstack/react-query';
+import { AxiosError } from 'axios';
+
+import { PatchPersonalInfoType } from '@repo/types';
+
+import { oneseoQueryKeys, oneseoUrl, patch } from '../../libs';
+
+export const usePatchPersonalInfo = (
+  options?: UseMutationOptions<unknown, AxiosError, PatchPersonalInfoType>,
+) =>
+  useMutation({
+    mutationKey: oneseoQueryKeys.patchPersonalInfo(),
+    mutationFn: (data) => patch(oneseoUrl.patchPersonalInfo(), data),
+    ...options,
+  });

--- a/packages/api/src/hooks/oneseo/usePatchPersonalInfoByMemberId.ts
+++ b/packages/api/src/hooks/oneseo/usePatchPersonalInfoByMemberId.ts
@@ -1,0 +1,16 @@
+import { useMutation, UseMutationOptions } from '@tanstack/react-query';
+import { AxiosError } from 'axios';
+
+import { PatchPersonalInfoType } from '@repo/types';
+
+import { oneseoQueryKeys, oneseoUrl, patch } from '../../libs';
+
+export const usePatchPersonalInfoByMemberId = (
+  memberId: number,
+  options?: UseMutationOptions<unknown, AxiosError, PatchPersonalInfoType>,
+) =>
+  useMutation({
+    mutationKey: oneseoQueryKeys.patchPersonalInfoByMemberId(memberId),
+    mutationFn: (data) => patch(oneseoUrl.patchPersonalInfoByMemberId(memberId), data),
+    ...options,
+  });

--- a/packages/api/src/libs/queryKeys.ts
+++ b/packages/api/src/libs/queryKeys.ts
@@ -26,6 +26,7 @@ export const oneseoQueryKeys = {
   getMyOneseo: () => ['get', 'my', 'oneseo'],
   getEditability: () => ['get', 'my', 'editability'],
   postExcel: () => ['post', 'excel'],
+  patchPersonalInfo: () => ['patch', 'personal', 'info'],
 } as const;
 
 export const memberQueryKeys = {

--- a/packages/api/src/libs/queryKeys.ts
+++ b/packages/api/src/libs/queryKeys.ts
@@ -27,6 +27,7 @@ export const oneseoQueryKeys = {
   getEditability: () => ['get', 'my', 'editability'],
   postExcel: () => ['post', 'excel'],
   patchPersonalInfo: () => ['patch', 'personal', 'info'],
+  patchPersonalInfoByMemberId: (memberId: number) => ['patch', 'personal', 'info', memberId],
 } as const;
 
 export const memberQueryKeys = {

--- a/packages/api/src/libs/requestUrlController.ts
+++ b/packages/api/src/libs/requestUrlController.ts
@@ -43,6 +43,7 @@ export const oneseoUrl = {
   getEditability: () => '/oneseo/v3/editability',
   postExcel: () => '/oneseo/v3/excel',
   patchPersonalInfo: () => '/oneseo/v3/personal-info/me',
+  patchPersonalInfoByMemberId: (memberId: number) => `/oneseo/v3/personal-info/${memberId}`,
 } as const;
 
 export const memberUrl = {

--- a/packages/api/src/libs/requestUrlController.ts
+++ b/packages/api/src/libs/requestUrlController.ts
@@ -42,6 +42,7 @@ export const oneseoUrl = {
   getAdmissionTickets: () => '/oneseo/v3/admission-tickets',
   getEditability: () => '/oneseo/v3/editability',
   postExcel: () => '/oneseo/v3/excel',
+  patchPersonalInfo: () => '/oneseo/v3/personal-info/me',
 } as const;
 
 export const memberUrl = {

--- a/packages/types/src/oneseo.ts
+++ b/packages/types/src/oneseo.ts
@@ -233,7 +233,7 @@ export interface PatchPersonalInfoType {
   address: string;
   detailAddress: string;
   profileImg: string;
-  graduationType: string;
+  graduationType: GraduationTypeValueEnum;
   schoolName?: string | null;
   schoolAddress?: string | null;
   studentNumber?: string | null;

--- a/packages/types/src/oneseo.ts
+++ b/packages/types/src/oneseo.ts
@@ -122,6 +122,9 @@ export interface PrivacyDetailType {
 }
 
 export interface PostOneseoType {
+  name?: string;
+  birth?: string;
+  sex?: SexType;
   guardianName?: string;
   guardianPhoneNumber?: string;
   relationshipWithGuardian?: string;
@@ -221,4 +224,23 @@ export interface TicketType {
 
 export interface EditabilityType {
   oneseoEditability: boolean;
+}
+
+export interface PatchPersonalInfoType {
+  name: string;
+  birth: string;
+  sex: SexType;
+  address: string;
+  detailAddress: string;
+  profileImg: string;
+  graduationType: string;
+  schoolName?: string | null;
+  schoolAddress?: string | null;
+  studentNumber?: string | null;
+  graduationDate?: string;
+  guardianName: string;
+  guardianPhoneNumber: string;
+  relationshipWithGuardian: string;
+  schoolTeacherName?: string | null;
+  schoolTeacherPhoneNumber?: string | null;
 }

--- a/packages/types/src/schemas/step1Schema.ts
+++ b/packages/types/src/schemas/step1Schema.ts
@@ -2,6 +2,9 @@ import { z } from 'zod';
 
 export const step1Schema = z.object({
   profileImg: z.string().min(1),
+  name: z.string().min(1),
+  birth: z.string().regex(/^\d{4}-\d{2}-\d{2}$/),
+  sex: z.enum(['MALE', 'FEMALE']),
   address: z.string().min(1),
   detailAddress: z.string().min(1),
 });

--- a/packages/ui/src/components/StepWrapper/index.tsx
+++ b/packages/ui/src/components/StepWrapper/index.tsx
@@ -65,7 +65,10 @@ const StepWrapper = ({ data, step, info, memberId, type }: StepWrapperProps) => 
       profileImg: data?.privacyDetail.profileImg,
       name: type === 'client' ? info?.name : data?.privacyDetail.name,
       birth: type === 'client' ? info?.birth : data?.privacyDetail.birth,
-      sex: (type === 'client' ? info?.sex : data?.privacyDetail.sex) as 'MALE' | 'FEMALE' | undefined,
+      sex: (type === 'client' ? info?.sex : data?.privacyDetail.sex) as
+        | 'MALE'
+        | 'FEMALE'
+        | undefined,
       address: data?.privacyDetail.address,
       detailAddress: data?.privacyDetail.detailAddress,
     },
@@ -180,7 +183,9 @@ const StepWrapper = ({ data, step, info, memberId, type }: StepWrapperProps) => 
   };
 
   const { mutateAsync: patchPersonalInfo } = usePatchPersonalInfo();
-  const { mutateAsync: patchPersonalInfoByMemberId } = usePatchPersonalInfoByMemberId(memberId ?? 0);
+  const { mutateAsync: patchPersonalInfoByMemberId } = usePatchPersonalInfoByMemberId(
+    memberId ?? 0,
+  );
 
   const { mutate: postMyOneseo } = usePostMyOneseo({
     onSuccess: () => setApplicationSubmitModal(true, type),
@@ -339,9 +344,7 @@ const StepWrapper = ({ data, step, info, memberId, type }: StepWrapperProps) => 
       schoolAddress: schoolAddress ?? null,
       studentNumber: studentNumber ?? null,
       graduationDate:
-        graduationDate && graduationDate.split('-')[0] !== '0000'
-          ? graduationDate
-          : undefined,
+        graduationDate && graduationDate.split('-')[0] !== '0000' ? graduationDate : undefined,
       guardianName: guardianName!,
       guardianPhoneNumber: guardianPhoneNumber!,
       relationshipWithGuardian:

--- a/packages/ui/src/components/StepWrapper/index.tsx
+++ b/packages/ui/src/components/StepWrapper/index.tsx
@@ -10,6 +10,7 @@ import { toast } from 'react-toastify';
 
 import {
   usePatchPersonalInfo,
+  usePatchPersonalInfoByMemberId,
   usePostMockScore,
   usePostMyOneseo,
   usePostTempStorage,
@@ -179,6 +180,7 @@ const StepWrapper = ({ data, step, info, memberId, type }: StepWrapperProps) => 
   };
 
   const { mutateAsync: patchPersonalInfo } = usePatchPersonalInfo();
+  const { mutateAsync: patchPersonalInfoByMemberId } = usePatchPersonalInfoByMemberId(memberId ?? 0);
 
   const { mutate: postMyOneseo } = usePostMyOneseo({
     onSuccess: () => setApplicationSubmitModal(true, type),
@@ -363,7 +365,7 @@ const StepWrapper = ({ data, step, info, memberId, type }: StepWrapperProps) => 
   };
 
   const handleOneseoEditButtonClick = async () => {
-    await patchPersonalInfo(getPersonalInfo());
+    await patchPersonalInfoByMemberId(getPersonalInfo());
     putOneseoByMemberId(getOneseo());
   };
 

--- a/packages/ui/src/components/StepWrapper/index.tsx
+++ b/packages/ui/src/components/StepWrapper/index.tsx
@@ -426,9 +426,13 @@ const StepWrapper = ({ data, step, info, memberId, type }: StepWrapperProps) => 
       step !== StepEnum.ONE &&
       isClient &&
       step1UseForm.formState.isDirty &&
-      isStepSuccess[1]
+      isStepSuccess[1] &&
+      isStepSuccess[2] &&
+      isStepSuccess[3]
     ) {
-      patchPersonalInfo(getPersonalInfo());
+      patchPersonalInfo(getPersonalInfo()).catch(() => {
+        toast.error('인적사항 자동 저장에 실패하였습니다.');
+      });
     }
   }, [step]);
 

--- a/packages/ui/src/components/StepWrapper/index.tsx
+++ b/packages/ui/src/components/StepWrapper/index.tsx
@@ -4,11 +4,12 @@
 
 import { zodResolver } from '@hookform/resolvers/zod';
 import { useRouter } from 'next/navigation';
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { useForm } from 'react-hook-form';
 import { toast } from 'react-toastify';
 
 import {
+  usePatchPersonalInfo,
   usePostMockScore,
   usePostMyOneseo,
   usePostTempStorage,
@@ -23,6 +24,7 @@ import {
   LiberalSystemValueEnum,
   MiddleSchoolAchievementType,
   MyMemberInfoType,
+  PatchPersonalInfoType,
   PostOneseoType,
   RelationshipWithGuardianValueEnum,
   Step1FormType,
@@ -60,6 +62,9 @@ const StepWrapper = ({ data, step, info, memberId, type }: StepWrapperProps) => 
     resolver: zodResolver(step1Schema),
     defaultValues: {
       profileImg: data?.privacyDetail.profileImg,
+      name: type === 'client' ? info?.name : data?.privacyDetail.name,
+      birth: type === 'client' ? info?.birth : data?.privacyDetail.birth,
+      sex: (type === 'client' ? info?.sex : data?.privacyDetail.sex) as 'MALE' | 'FEMALE' | undefined,
       address: data?.privacyDetail.address,
       detailAddress: data?.privacyDetail.detailAddress,
     },
@@ -150,9 +155,6 @@ const StepWrapper = ({ data, step, info, memberId, type }: StepWrapperProps) => 
 
   const BASE_URL = isClient ? '/register' : `/edit/${memberId}`;
 
-  const name = isClient ? info!.name : data!.privacyDetail.name;
-  const birth = isClient ? info!.birth : data!.privacyDetail.birth;
-  const sex = isClient ? info!.sex : data!.privacyDetail.sex;
   const phoneNumber = isClient ? info!.phoneNumber : data!.privacyDetail.phoneNumber;
 
   const isStepSuccess = {
@@ -175,6 +177,8 @@ const StepWrapper = ({ data, step, info, memberId, type }: StepWrapperProps) => 
   const clearStepError = () => {
     setErrorStep(null);
   };
+
+  const { mutateAsync: patchPersonalInfo } = usePatchPersonalInfo();
 
   const { mutate: postMyOneseo } = usePostMyOneseo({
     onSuccess: () => setApplicationSubmitModal(true, type),
@@ -204,7 +208,7 @@ const StepWrapper = ({ data, step, info, memberId, type }: StepWrapperProps) => 
   });
 
   const getOneseo = (isTemp: boolean = false) => {
-    const { profileImg, address, detailAddress } = step1UseForm.watch();
+    const { profileImg, name, birth, sex, address, detailAddress } = step1UseForm.watch();
     const {
       graduationType,
       schoolName,
@@ -244,6 +248,9 @@ const StepWrapper = ({ data, step, info, memberId, type }: StepWrapperProps) => 
     const body: PostOneseoType = {
       // step 1
       profileImg: profileImg || undefined,
+      name: name || undefined,
+      birth: birth || undefined,
+      sex: sex || undefined,
       address: address || undefined,
       detailAddress: detailAddress || undefined,
 
@@ -305,10 +312,48 @@ const StepWrapper = ({ data, step, info, memberId, type }: StepWrapperProps) => 
     return body;
   };
 
-  const handleOneseoSubmitButtonClick = () => {
-    const body = getOneseo();
+  const getPersonalInfo = (): PatchPersonalInfoType => {
+    const { profileImg, name, birth, sex, address, detailAddress } = step1UseForm.watch();
+    const { graduationType, schoolName, schoolAddress, studentNumber, graduationDate } =
+      step2UseForm.watch();
+    const {
+      guardianName,
+      guardianPhoneNumber,
+      relationshipWithGuardian,
+      otherRelationshipWithGuardian,
+      schoolTeacherName,
+      schoolTeacherPhoneNumber,
+    } = step3UseForm.watch();
 
-    postMyOneseo(body);
+    return {
+      profileImg: profileImg!,
+      name: name!,
+      birth: birth!,
+      sex: sex!,
+      address: address!,
+      detailAddress: detailAddress!,
+      graduationType: graduationType!,
+      schoolName: schoolName ?? null,
+      schoolAddress: schoolAddress ?? null,
+      studentNumber: studentNumber ?? null,
+      graduationDate:
+        graduationDate && graduationDate.split('-')[0] !== '0000'
+          ? graduationDate
+          : undefined,
+      guardianName: guardianName!,
+      guardianPhoneNumber: guardianPhoneNumber!,
+      relationshipWithGuardian:
+        (relationshipWithGuardian === RelationshipWithGuardianValueEnum.OTHER
+          ? otherRelationshipWithGuardian
+          : relationshipWithGuardian) ?? '',
+      schoolTeacherName: schoolTeacherName ?? null,
+      schoolTeacherPhoneNumber: schoolTeacherPhoneNumber ?? null,
+    };
+  };
+
+  const handleOneseoSubmitButtonClick = async () => {
+    await patchPersonalInfo(getPersonalInfo());
+    postMyOneseo(getOneseo());
   };
 
   const handleTemporarySaveButtonClick = () => {
@@ -317,10 +362,9 @@ const StepWrapper = ({ data, step, info, memberId, type }: StepWrapperProps) => 
     postTempStorage(body);
   };
 
-  const handleOneseoEditButtonClick = () => {
-    const body = getOneseo();
-
-    putOneseoByMemberId(body);
+  const handleOneseoEditButtonClick = async () => {
+    await patchPersonalInfo(getPersonalInfo());
+    putOneseoByMemberId(getOneseo());
   };
 
   const handleCheckScoreButtonClick = () => {
@@ -365,6 +409,23 @@ const StepWrapper = ({ data, step, info, memberId, type }: StepWrapperProps) => 
 
     postMockScore(body);
   };
+
+  const prevStepRef = useRef<StepEnum>(step);
+
+  useEffect(() => {
+    const prevStep = prevStepRef.current;
+    prevStepRef.current = step;
+
+    if (
+      prevStep === StepEnum.ONE &&
+      step !== StepEnum.ONE &&
+      isClient &&
+      step1UseForm.formState.isDirty &&
+      isStepSuccess[1]
+    ) {
+      patchPersonalInfo(getPersonalInfo());
+    }
+  }, [step]);
 
   useEffect(() => {
     if (errorStep !== step) clearStepError();
@@ -424,9 +485,6 @@ const StepWrapper = ({ data, step, info, memberId, type }: StepWrapperProps) => 
             {step === StepEnum.ONE && (
               <Step1Register
                 {...step1UseForm}
-                name={name}
-                birth={birth}
-                sex={sex}
                 phoneNumber={phoneNumber}
                 showError={errorStep === StepEnum.ONE}
               />

--- a/packages/ui/src/components/register/Step1Register/index.tsx
+++ b/packages/ui/src/components/register/Step1Register/index.tsx
@@ -158,10 +158,7 @@ const Step1Register = ({
             fullWidth={true}
           >
             <div className={cn('flex', 'w-full', 'justify-between')}>
-              <Select
-                value={birthYear || ''}
-                onValueChange={handleBirthYearChange}
-              >
+              <Select value={birthYear || ''} onValueChange={handleBirthYearChange}>
                 <SelectTrigger
                   className={cn('w-[9.3785rem]', showError && errors.birth && '!border-red-600')}
                 >

--- a/packages/ui/src/components/register/Step1Register/index.tsx
+++ b/packages/ui/src/components/register/Step1Register/index.tsx
@@ -10,16 +10,23 @@ import {
   FormState,
 } from 'react-hook-form';
 
-import { SexType, SexValueEnum, Step1FormType } from '@repo/types';
+import { SexValueEnum, Step1FormType } from '@repo/types';
 import { cn } from '@repo/utils';
 
 import { UploadPhoto, RadioButton, CustomFormItem } from '../../';
-import { Button, Input, Select, SelectTrigger, SelectValue } from '../../../shadcn';
+import {
+  Button,
+  Input,
+  Select,
+  SelectContent,
+  SelectGroup,
+  SelectItem,
+  SelectLabel,
+  SelectTrigger,
+  SelectValue,
+} from '../../../shadcn';
 
 interface Step1RegisterProps {
-  name: string;
-  birth: string;
-  sex: SexType;
   phoneNumber: string;
   register: UseFormRegister<Step1FormType>;
   setValue: UseFormSetValue<Step1FormType>;
@@ -29,10 +36,11 @@ interface Step1RegisterProps {
   showError: boolean;
 }
 
+const BIRTH_YEARS = Array.from({ length: 20 }, (_, i) => 2015 - i);
+const BIRTH_MONTHS = Array.from({ length: 12 }, (_, i) => i + 1);
+const BIRTH_DAYS = Array.from({ length: 31 }, (_, i) => i + 1);
+
 const Step1Register = ({
-  name,
-  birth,
-  sex,
   phoneNumber,
   register,
   setValue,
@@ -43,11 +51,9 @@ const Step1Register = ({
 }: Step1RegisterProps) => {
   const daumPostCode = useDaumPostcodePopup();
 
-  // 개선 필요해보임
-  const birthDate = birth ? new Date(birth) : null;
-  const birthYear = birthDate ? birthDate.getFullYear() : '';
-  const birthMonth = birthDate ? String(birthDate.getMonth() + 1).padStart(2, '0') : '';
-  const birthDay = birthDate ? String(birthDate.getDate()).padStart(2, '0') : '';
+  const birth = watch('birth') || '';
+  const [birthYear, birthMonth, birthDay] = birth.split('-');
+
   const sexList = [
     { name: '남자', value: SexValueEnum.MALE },
     { name: '여자', value: SexValueEnum.FEMALE },
@@ -87,6 +93,30 @@ const Step1Register = ({
       onComplete: handleDaumPostCodePopupComplete,
     });
 
+  const handleBirthYearChange = (year: string) => {
+    const month = birthMonth || '01';
+    const day = birthDay || '01';
+    setValue('birth', `${year}-${month}-${day}`, { shouldValidate: true, shouldDirty: true });
+  };
+
+  const handleBirthMonthChange = (month: string) => {
+    const year = birthYear || '2000';
+    const day = birthDay || '01';
+    setValue('birth', `${year}-${month.padStart(2, '0')}-${day}`, {
+      shouldValidate: true,
+      shouldDirty: true,
+    });
+  };
+
+  const handleBirthDayChange = (day: string) => {
+    const year = birthYear || '2000';
+    const month = birthMonth || '01';
+    setValue('birth', `${year}-${month}-${day.padStart(2, '0')}`, {
+      shouldValidate: true,
+      shouldDirty: true,
+    });
+  };
+
   useEffect(() => {
     if (!showError) return;
 
@@ -106,7 +136,7 @@ const Step1Register = ({
           기본 정보를 입력해 주세요.
         </h1>
         <p className={cn('text-gray-600', 'text-[0.875rem]/[1.25rem]', 'font-normal')}>
-          회원가입 시 입력한 기본 정보가 노출됩니다.
+          전화번호를 제외한 인적사항을 수정할 수 있습니다.
         </p>
       </div>
 
@@ -114,7 +144,12 @@ const Step1Register = ({
         <div className={cn('flex', 'w-[29.75rem]', 'flex-col', 'items-start', 'gap-[2rem]')}>
           <UploadPhoto setValue={setValue} watch={watch} errors={errors} showError={showError} />
           <CustomFormItem text={'이름'} className={cn('gap-1')} required={true} fullWidth={true}>
-            <Input placeholder={name} disabled={true} />
+            <Input
+              {...register('name')}
+              placeholder="이름을 입력해 주세요"
+              width="full"
+              variant={showError && errors.name ? 'error' : null}
+            />
           </CustomFormItem>
           <CustomFormItem
             text={'생년월일'}
@@ -123,20 +158,65 @@ const Step1Register = ({
             fullWidth={true}
           >
             <div className={cn('flex', 'w-full', 'justify-between')}>
-              <Select>
-                <SelectTrigger className={cn('w-[9.3785rem]')} disabled={true}>
-                  <SelectValue placeholder={birthYear} />
+              <Select
+                value={birthYear || ''}
+                onValueChange={handleBirthYearChange}
+              >
+                <SelectTrigger
+                  className={cn('w-[9.3785rem]', showError && errors.birth && '!border-red-600')}
+                >
+                  <SelectValue placeholder="연도 선택" />
                 </SelectTrigger>
+                <SelectContent>
+                  <SelectGroup>
+                    <SelectLabel>연도 선택</SelectLabel>
+                    {BIRTH_YEARS.map((year) => (
+                      <SelectItem key={year} value={year.toString()}>
+                        {year}년
+                      </SelectItem>
+                    ))}
+                  </SelectGroup>
+                </SelectContent>
               </Select>
-              <Select>
-                <SelectTrigger className={cn('w-[9.3785rem]')} disabled={true}>
-                  <SelectValue placeholder={birthMonth} />
+              <Select
+                value={birthMonth ? Number(birthMonth).toString() : ''}
+                onValueChange={handleBirthMonthChange}
+              >
+                <SelectTrigger
+                  className={cn('w-[9.3785rem]', showError && errors.birth && '!border-red-600')}
+                >
+                  <SelectValue placeholder="월 선택" />
                 </SelectTrigger>
+                <SelectContent>
+                  <SelectGroup>
+                    <SelectLabel>월 선택</SelectLabel>
+                    {BIRTH_MONTHS.map((month) => (
+                      <SelectItem key={month} value={month.toString()}>
+                        {month}월
+                      </SelectItem>
+                    ))}
+                  </SelectGroup>
+                </SelectContent>
               </Select>
-              <Select>
-                <SelectTrigger className={cn('w-[9.3785rem]')} disabled={true}>
-                  <SelectValue placeholder={birthDay} />
+              <Select
+                value={birthDay ? Number(birthDay).toString() : ''}
+                onValueChange={handleBirthDayChange}
+              >
+                <SelectTrigger
+                  className={cn('w-[9.3785rem]', showError && errors.birth && '!border-red-600')}
+                >
+                  <SelectValue placeholder="일 선택" />
                 </SelectTrigger>
+                <SelectContent>
+                  <SelectGroup>
+                    <SelectLabel>일 선택</SelectLabel>
+                    {BIRTH_DAYS.map((day) => (
+                      <SelectItem key={day} value={day.toString()}>
+                        {day}일
+                      </SelectItem>
+                    ))}
+                  </SelectGroup>
+                </SelectContent>
               </Select>
             </div>
           </CustomFormItem>
@@ -147,8 +227,14 @@ const Step1Register = ({
             title={'성별'}
             list={sexList}
             required={true}
-            disabled={true}
-            selectedValue={sex}
+            selectedValue={watch('sex') || ''}
+            handleOptionClick={(value) =>
+              setValue('sex', value as 'MALE' | 'FEMALE', {
+                shouldValidate: true,
+                shouldDirty: true,
+              })
+            }
+            error={showError && !!errors.sex}
           />
 
           <div className={cn('flex', 'flex-col', 'items-start', 'gap-[0.375rem]', 'w-full')}>

--- a/packages/ui/src/shadcn/dialog.tsx
+++ b/packages/ui/src/shadcn/dialog.tsx
@@ -49,7 +49,7 @@ const DialogContent = React.forwardRef<
     <DialogPrimitive.Content
       ref={ref}
       className={cn([
-        'bg-background data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] fixed top-[50%] left-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border p-6 shadow-lg duration-200 sm:rounded-lg',
+        'fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg',
         className,
       ])}
       {...props}
@@ -116,7 +116,7 @@ const DialogTitle = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <DialogPrimitive.Title
     ref={ref}
-    className={cn(['text-lg leading-none font-semibold tracking-tight', className])}
+    className={cn(['text-lg font-semibold leading-none tracking-tight', className])}
     {...props}
   />
 ));

--- a/packages/ui/src/shadcn/form.tsx
+++ b/packages/ui/src/shadcn/form.tsx
@@ -149,7 +149,7 @@ const FormMessage = React.forwardRef<
     <p
       ref={ref}
       id={formMessageId}
-      className={cn(['text-destructive text-sm font-medium', className])}
+      className={cn(['text-sm font-medium text-destructive', className])}
       {...props}
     >
       {body}

--- a/packages/ui/src/shadcn/input.tsx
+++ b/packages/ui/src/shadcn/input.tsx
@@ -8,7 +8,7 @@ const inputVariants = cva(cn(''), {
     variant: {
       default: cn('focus-visible:border-slate-900'),
       blueOutline: cn('focus-visible:border-blue-500'),
-      error: cn('!border-red-600'),
+      error: cn('!border-red-600', 'disabled:!opacity-100'),
     },
     width: {
       full: cn('w-full'),


### PR DESCRIPTION
## 개요 💡

클라이언트와 어드민 모두에서 원서 Step1의 인적사항(전화번호 제외)을 수정할 수 있도록 기능을 구현합니다.
기존에는 Step1의 이름, 생년월일, 성별 필드가 비활성화(disabled) 상태로 표시만 되었으나, 수정 가능한 입력 필드로 변경했습니다.

## 작업내용 ⌨️
**클라이언트**
- Step1의 이름, 생년월일, 성별 필드를 수정 가능한 폼 입력으로 변경 
- `PATCH /oneseo/v3/personal-info/me` API를 연동하여 원서 제출 시 및 Step1에서 다른 스텝으로 이동 시 인적사항 자동 저장

**어드민**
- `PATCH /oneseo/v3/personal-info/{memberId}` API 훅(usePatchPersonalInfoByMemberId) 추가
- 어드민 원서 수정 페이지에서 저장 시 memberId 기반 인적사항 수정 API 호출하도록 연동

**공통**
- `PatchPersonalInfoType` 타입 및 `getPersonalInfo() `유틸 함수 추가
- 전화번호 필드는 수정 불가 상태 유지

## 스크린샷/동영상 📸
클라이언트

https://github.com/user-attachments/assets/585eaa0b-d1e7-4ec7-ae6d-7d61efa1304f



어드민

https://github.com/user-attachments/assets/934a0210-d787-4e90-86af-93082aef327f



## 관련 이슈 🚨

https://github.com/themoment-team/hellogsm-front-25/issues/391
