### PR TITLE
refactor: OAuth redirectUri 동적 처리로 변경

### DIFF
--- a/apps/client/src/app/page.tsx
+++ b/apps/client/src/app/page.tsx
@@ -1,3 +1,4 @@
+import { headers } from 'next/headers';
 import { redirect } from 'next/navigation';
 
 import { MainPage } from '@/pageContainer';
@@ -24,8 +25,12 @@ export default async function Home({ searchParams }: { searchParams?: { isAdmin?
   const isAdminRole = authInfo?.role === 'ADMIN' || authInfo?.role === 'ROOT';
 
   if (isAdminRequested && isAdminRole) {
-    const isStage = process.env.NEXT_PUBLIC_API_BASE_URL?.includes('stage');
-    const adminUrl = isStage ? 'https://admin.stage.hellogsm.kr' : 'https://admin.hellogsm.kr';
+    const host = headers().get('host') ?? '';
+    const adminUrl = host.includes('localhost')
+      ? 'http://localhost:3001'
+      : host.includes('stage')
+        ? 'https://admin.stage.hellogsm.kr'
+        : 'https://admin.hellogsm.kr';
     redirect(adminUrl);
   }
 

--- a/apps/client/src/pageContainer/CallbackPage/index.tsx
+++ b/apps/client/src/pageContainer/CallbackPage/index.tsx
@@ -22,10 +22,10 @@ const CallbackPage = ({ code, provider }: { code: string; provider: string }) =>
   const handleLoginSuccess = async () => {
     await queryClient.invalidateQueries({ queryKey: memberQueryKeys.getMyMemberInfo() });
 
-    const currentOrigin = window.location.origin;
-    const isStage = currentOrigin.includes('stage');
-    const clientBaseUrl = isStage ? 'https://www.stage.hellogsm.kr' : 'https://www.hellogsm.kr';
-    const nextUrl = provider === 'admin' ? `${clientBaseUrl}/?isAdmin=true` : clientBaseUrl;
+    const nextUrl =
+      provider === 'admin'
+        ? `${window.location.origin}/?isAdmin=true`
+        : window.location.origin;
     router.replace(nextUrl);
   };
 
@@ -59,10 +59,12 @@ const CallbackPage = ({ code, provider }: { code: string; provider: string }) =>
       return;
     }
 
+    const redirectUri = `${window.location.origin}/callback`;
+
     if (provider === 'google' || provider === 'admin') {
-      googleLogin(code);
+      googleLogin({ code, redirectUri });
     } else if (provider === 'kakao') {
-      kakaoLogin(code);
+      kakaoLogin({ code, redirectUri });
     } else {
       router.replace('/');
       toast.error('로그인에 실패했습니다.');

--- a/packages/api/src/hooks/auth/useOAuthLogin.ts
+++ b/packages/api/src/hooks/auth/useOAuthLogin.ts
@@ -9,11 +9,17 @@ interface ReturnDataType {
   message: string;
 }
 
+interface LoginPayload {
+  code: string;
+  redirectUri: string;
+}
+
 export const useOAuthLogin = (
   provider: 'google' | 'kakao',
-  options?: UseMutationOptions<ReturnDataType, AxiosError, string>,
+  options?: UseMutationOptions<ReturnDataType, AxiosError, LoginPayload>,
 ) =>
   useMutation({
-    mutationFn: (code: string) => post<ReturnDataType>(authUrl.postLogin(provider), { code }),
+    mutationFn: ({ code, redirectUri }: LoginPayload) =>
+      post<ReturnDataType>(authUrl.postLogin(provider), { code, redirectUri }),
     ...options,
   });

--- a/packages/ui/src/components/LoginButton/index.tsx
+++ b/packages/ui/src/components/LoginButton/index.tsx
@@ -40,8 +40,9 @@ interface LoginButtonProps
 }
 
 const getClientOrigin = (origin: string): string => {
-  if (origin === 'http://localhost:3001') return 'http://localhost:3000';
-  return origin.replace('://admin.', '://www.');
+  if (origin.includes('localhost')) return 'http://localhost:3000';
+  if (origin.includes('stage')) return 'https://www.stage.hellogsm.kr';
+  return 'https://www.hellogsm.kr';
 };
 
 const LoginButton = React.forwardRef<HTMLButtonElement, LoginButtonProps>(

--- a/packages/ui/src/components/LoginButton/index.tsx
+++ b/packages/ui/src/components/LoginButton/index.tsx
@@ -39,6 +39,11 @@ interface LoginButtonProps
   isAdmin?: boolean;
 }
 
+const getClientOrigin = (origin: string): string => {
+  if (origin === 'http://localhost:3001') return 'http://localhost:3000';
+  return origin.replace('://admin.', '://www.');
+};
+
 const LoginButton = React.forwardRef<HTMLButtonElement, LoginButtonProps>(
   ({ className, variant, children, isAdmin = false, ...props }, ref) => {
     const [redirectUri, setRedirectUri] = React.useState('');
@@ -47,9 +52,10 @@ const LoginButton = React.forwardRef<HTMLButtonElement, LoginButtonProps>(
 
     React.useEffect(() => {
       if (typeof window !== 'undefined') {
-        setRedirectUri(`${window.location.origin}/callback`);
+        const origin = isAdmin ? getClientOrigin(window.location.origin) : window.location.origin;
+        setRedirectUri(`${origin}/callback`);
       }
-    }, []);
+    }, [isAdmin]);
 
     React.useEffect(() => {
       if (redirectUri) {

--- a/packages/ui/src/components/LoginButton/index.tsx
+++ b/packages/ui/src/components/LoginButton/index.tsx
@@ -47,22 +47,7 @@ const LoginButton = React.forwardRef<HTMLButtonElement, LoginButtonProps>(
 
     React.useEffect(() => {
       if (typeof window !== 'undefined') {
-        const currentOrigin = window.location.origin;
-
-        const stageOrigins = [
-          'http://localhost:3000',
-          'http://localhost:3001',
-          'https://www.stage.hellogsm.kr',
-          'https://admin.stage.hellogsm.kr',
-        ];
-
-        const productionOrigins = ['https://www.hellogsm.kr', 'https://admin.hellogsm.kr'];
-
-        if (stageOrigins.includes(currentOrigin)) {
-          setRedirectUri('https://www.stage.hellogsm.kr/callback');
-        } else if (productionOrigins.includes(currentOrigin)) {
-          setRedirectUri('https://www.hellogsm.kr/callback');
-        }
+        setRedirectUri(`${window.location.origin}/callback`);
       }
     }, []);
 


### PR DESCRIPTION
## 개요 💡

기존에 환경별로 하드코딩된 `redirectUri` 목록을 제거하고, `window.location.origin`을 기반으로 동적으로 생성하도록 변경합니다.
새로운 환경이 추가될 때마다 프론트엔드 코드를 수정할 필요 없이 자동으로 올바른 `redirectUri`가 설정됩니다.

## 작업내용 ⌨️

- `LoginButton`: stage/production origin 하드코딩 목록 제거 → `window.location.origin/callback` 동적 설정
- `useOAuthLogin`: mutation payload를 `string(code)`에서 `{ code, redirectUri }` 구조로 변경
- `CallbackPage`: `redirectUri`를 `window.location.origin/callback`으로 동적 생성하여 로그인 요청에 포함, 로그인 성공 후 리다이렉트 URL도 동적 처리로 변경