### PR TITLE
[fix] 모의 성적 계산하기 유형 전환 시 폼 리셋 누락 수정

### DIFF
--- a/apps/client/src/pageContainer/CalculatePage/index.tsx
+++ b/apps/client/src/pageContainer/CalculatePage/index.tsx
@@ -111,6 +111,15 @@ const CalculatePage = () => {
     }
   };
 
+  const handleBackClick = () => {
+    step4UseForm.reset({
+      liberalSystem: LiberalSystemValueEnum.FREE_SEMESTER,
+      freeSemester: null,
+    });
+    setErrorStep(null);
+    setGraduationType(null);
+  };
+
   return (
     <>
       <ComputerRecommendedPage type="calculate" />
@@ -131,7 +140,7 @@ const CalculatePage = () => {
                 'border-gray-100',
               )}
             >
-              <Button onClick={() => setGraduationType(null)} variant="ghost">
+              <Button onClick={handleBackClick} variant="ghost">
                 이전
               </Button>
               <Button

--- a/apps/client/src/pageContainer/CalculatePage/index.tsx
+++ b/apps/client/src/pageContainer/CalculatePage/index.tsx
@@ -115,6 +115,7 @@ const CalculatePage = () => {
     step4UseForm.reset({
       liberalSystem: LiberalSystemValueEnum.FREE_SEMESTER,
       freeSemester: null,
+      gedAvgScore: null,
     });
     setErrorStep(null);
     setGraduationType(null);

--- a/apps/client/src/pageContainer/CalculatePage/index.tsx
+++ b/apps/client/src/pageContainer/CalculatePage/index.tsx
@@ -36,6 +36,7 @@ const CalculatePage = () => {
     defaultValues: {
       liberalSystem: LiberalSystemValueEnum.FREE_SEMESTER,
       freeSemester: null,
+      gedAvgScore: null,
     },
   });
 


### PR DESCRIPTION
## 개요 💡
모의 성적 계산하기에서 검정고시 유형으로 입력 후 "이전" 버튼을 눌러 다른 유형(졸업 예정/졸업자)으로 전환하면, 모든 값을 입력해도 "내 성적 계산하기" 버튼이 활성화되지 않는 버그를 수정했습니다.

## 작업내용 ⌨️

- "이전" 버튼 클릭 시 호출되는 `handleBackClick`에서 `step4UseForm.reset()`을 호출해 폼 상태를 초기화하는데, 이때 전달하는 reset 객체에 `gedAvgScore` 필드가 누락되어 있었습니다.
- `gedAvgScore`는 스키마상 `z.nullable(z.number()...)`로 정의되어 있어 null은 허용하지만 `undefined`는 허용하지 않습니다. reset 객체에 포함되지 않은 필드는 RHF에 의해 `undefined`로 초기화되기 때문에, reset 직후 `gedAvgScore`가 `undefined` 상태가 되어 `step4Schema.safeParse()`가 실패하고 `isStep4Success`가 계속 false로 고정되었습니다.
- 이로 인해 다른 유형으로 전환한 뒤 폼을 빠짐없이 채워도 검증이 통과되지 못해 "내 성적 계산하기" 버튼이 영구적으로 비활성화 상태에 머무르게 됩니다.
- `handleBackClick`의 reset 객체에 `gedAvgScore: null`을 추가하여, 유형 전환 시 폼이 정상적으로 valid 상태가 되도록 수정했습니다.

## 관련 이슈 🚨
모의 성적 계산하기 → 검정고시로 입력 후 "이전" → 다른 유형 선택 후 입력 시 "내 성적 계산하기" 버튼이 활성화되지 않는 문제
https://github.com/themoment-team/hellogsm-client-26/issues/410