### PR TITLE
[chore] client next.config.mjs output standalone 제거

### DIFF
--- a/apps/client/next.config.mjs
+++ b/apps/client/next.config.mjs
@@ -18,7 +18,6 @@ const nextConfig = {
       destination: `${process.env.NEXT_PUBLIC_API_BASE_URL}/:path*`,
     },
   ],
-  output: 'standalone',
 };
 
 export default nextConfig;

--- a/vercel.json
+++ b/vercel.json
@@ -1,5 +1,0 @@
-{
-  "buildCommand": "pnpm turbo run build --filter=client",
-  "outputDirectory": "apps/client/.next",
-  "installCommand": "pnpm install --frozen-lockfile"
-}

--- a/vercel.json
+++ b/vercel.json
@@ -1,6 +1,5 @@
 {
   "buildCommand": "pnpm turbo run build --filter=client",
   "outputDirectory": "apps/client/.next",
-  "installCommand": "pnpm install --frozen-lockfile",
-  "framework": "nextjs"
+  "installCommand": "pnpm install --frozen-lockfile"
 }

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,6 @@
+{
+  "buildCommand": "pnpm turbo run build --filter=client",
+  "outputDirectory": "apps/client/.next",
+  "installCommand": "pnpm install --frozen-lockfile",
+  "framework": "nextjs"
+}


### PR DESCRIPTION
## 개요 💡
Vercel 배포를 위한 설정 작업입니다.
모노레포 구조에서 Root Directory를 apps/client로 설정하는 방식으로 Vercel 배포 문제를 해결했습니다.
## 작업내용 ⌨️

- `apps/client/next.config.mjs`에서 `output: 'standalone'` 제거
- Vercel 배포 시 standalone 모드 불필요


## 관련 이슈 🚨

AWS → Vercel 이전 작업의 일환

