### PR TITLE
[style] 2027학년도 입학원서 서식 변경사항 작업

### DIFF
--- a/packages/ui/src/components/ApplicationPrintPage/ApplicationForm/index.tsx
+++ b/packages/ui/src/components/ApplicationPrintPage/ApplicationForm/index.tsx
@@ -118,7 +118,7 @@ const ApplicationForm = ({ oneseo, isPreview }: ApplicationFormProps) => {
           </div>
 
           <div className={cn('my-4', 'text-center')}>
-            2차 전형 응시 준비물 : 신분증[학생증], 필기구 등
+            ** 2차 전형 응시 준비물: 신분증(학생증), 필기구
           </div>
         </div>
       </div>

--- a/packages/ui/src/components/ApplicationPrintPage/ApplicationPledge/index.tsx
+++ b/packages/ui/src/components/ApplicationPrintPage/ApplicationPledge/index.tsx
@@ -17,14 +17,22 @@ const ApplicationPledge = ({ oneseo }: OneseoStatusType) => {
         <p className={cn('mr-6')}>월</p>
         <p>일</p>
       </div>
-      <div className={cn('mb-4', 'flex', 'w-full', 'justify-end', 'gap-6')}>
+      <div className={cn('mb-1', 'flex', 'w-full', 'justify-end', 'gap-6')}>
         <p>지원자 :</p>
         <p>{oneseo.privacyDetail.name}</p>
         <p className={cn('text-end')}>(인)</p>
       </div>
-      <div className={cn('mb-4', 'flex', 'w-full', 'justify-end', 'gap-6')}>
+      <div className={cn('mb-1', 'flex', 'w-full', 'justify-end', 'gap-6')}>
         <p>보호자 :</p>
         <p>{oneseo.privacyDetail.guardianName}</p>
+        <p className={cn('text-end')}>(인)</p>
+      </div>
+      <div className={cn('mb-4', 'flex', 'w-full', 'justify-end', 'gap-6')}>
+        <p>담임 :</p>
+        <p>
+          {oneseo.privacyDetail.graduationType === 'CANDIDATE' &&
+            oneseo.privacyDetail.schoolTeacherName}
+        </p>
         <p className={cn('text-end')}>(인)</p>
       </div>
       <div className={cn('text-left')}>광주소프트웨어마이스터고등학교장 귀하</div>

--- a/packages/ui/src/components/ApplicationPrintPage/ApplicationPledge/index.tsx
+++ b/packages/ui/src/components/ApplicationPrintPage/ApplicationPledge/index.tsx
@@ -22,19 +22,26 @@ const ApplicationPledge = ({ oneseo }: OneseoStatusType) => {
         <p>{oneseo.privacyDetail.name}</p>
         <p className={cn('text-end')}>(인)</p>
       </div>
-      <div className={cn('mb-1', 'flex', 'w-full', 'justify-end', 'gap-6')}>
+      <div
+        className={cn(
+          oneseo.privacyDetail.graduationType === 'CANDIDATE' ? 'mb-1' : 'mb-4',
+          'flex',
+          'w-full',
+          'justify-end',
+          'gap-6',
+        )}
+      >
         <p>보호자 :</p>
         <p>{oneseo.privacyDetail.guardianName}</p>
         <p className={cn('text-end')}>(인)</p>
       </div>
-      <div className={cn('mb-4', 'flex', 'w-full', 'justify-end', 'gap-6')}>
-        <p>담임 :</p>
-        <p>
-          {oneseo.privacyDetail.graduationType === 'CANDIDATE' &&
-            oneseo.privacyDetail.schoolTeacherName}
-        </p>
-        <p className={cn('text-end')}>(인)</p>
-      </div>
+      {oneseo.privacyDetail.graduationType === 'CANDIDATE' && (
+        <div className={cn('mb-4', 'flex', 'w-full', 'justify-end', 'gap-6')}>
+          <p>담임 :</p>
+          <p>{oneseo.privacyDetail.schoolTeacherName}</p>
+          <p className={cn('text-end')}>(인)</p>
+        </div>
+      )}
       <div className={cn('text-left')}>광주소프트웨어마이스터고등학교장 귀하</div>
       {oneseo.privacyDetail.graduationType !== 'GED' && (
         <>

--- a/packages/ui/src/components/ApplicationPrintPage/FormColgroup.tsx
+++ b/packages/ui/src/components/ApplicationPrintPage/FormColgroup.tsx
@@ -1,0 +1,14 @@
+// 인적사항 표와 지원자현황 표의 세로선을 맞추기 위해 두 표가 공유하는 컬럼 너비입니다.
+const FORM_COLUMN_WIDTHS = [3, 6, 8, 8, 8, 8, 8, 8, 10, 8, 9, 8, 9];
+
+const FormColgroup = () => {
+  return (
+    <colgroup>
+      {FORM_COLUMN_WIDTHS.map((width, index) => (
+        <col key={index} style={{ width: `${width}%` }} />
+      ))}
+    </colgroup>
+  );
+};
+
+export default FormColgroup;

--- a/packages/ui/src/components/ApplicationPrintPage/OneseoStatus/index.tsx
+++ b/packages/ui/src/components/ApplicationPrintPage/OneseoStatus/index.tsx
@@ -7,12 +7,21 @@ import {
 } from '@repo/types';
 import { cn } from '@repo/utils';
 
+import FormColgroup from '../FormColgroup';
+
 const tdStyle = 'border border-black';
 const thStyle = 'border border-black bg-[#e9e9e9] p-[0.2vh] font-medium align-middle';
 
 const OneseoStatus = ({ oneseo }: OneseoStatusType) => {
-  const { graduationDate, graduationType, schoolName, schoolAddress, studentNumber } =
-    oneseo.privacyDetail;
+  const {
+    graduationDate,
+    graduationType,
+    schoolName,
+    schoolAddress,
+    studentNumber,
+    schoolTeacherName,
+    schoolTeacherPhoneNumber,
+  } = oneseo.privacyDetail;
   const {
     attendanceScore,
     volunteerScore,
@@ -46,33 +55,19 @@ const OneseoStatus = ({ oneseo }: OneseoStatusType) => {
         'leading-[2.2vh]',
       )}
     >
-      <colgroup>
-        <col style={{ width: '3%' }} /> {/* 지원자현황 */}
-        <col style={{ width: '6%' }} /> {/* 교과성적 */}
-        <col style={{ width: '8%' }} /> {/* 1-1 */}
-        <col style={{ width: '8%' }} /> {/* 1-2 */}
-        <col style={{ width: '8%' }} /> {/* 2-1 */}
-        <col style={{ width: '8%' }} /> {/* 2-2 */}
-        <col style={{ width: '8%' }} /> {/* 3-1 */}
-        <col style={{ width: '8%' }} /> {/* 3-2 */}
-        <col style={{ width: '10%' }} /> {/* 예체능 */}
-        <col style={{ width: '8%' }} /> {/* 소계1 */}
-        <col style={{ width: '9%' }} /> {/* 소계2 */}
-        <col style={{ width: '8%' }} /> {/* 합계1 */}
-        <col style={{ width: '9%' }} /> {/* 합계2 */}
-      </colgroup>
+      <FormColgroup />
       <tbody>
         <tr>
-          <td className={cn(thStyle, 'w-[3%]', 'border-l-0', 'border-t-0')} rowSpan={9}>
+          <td className={cn(thStyle, 'w-[3%]', 'border-l-0', 'border-t-0')} rowSpan={10}>
             지원자 현황
           </td>
         </tr>
         <tr>
-          <td className={cn(thStyle, 'border-t-0')} colSpan={2} rowSpan={2}>
+          <td className={cn(thStyle, 'border-t-0')} colSpan={2} rowSpan={3}>
             출신중학교
           </td>
           <td
-            colSpan={3}
+            colSpan={4}
             className={cn(
               tdStyle,
               isGED && ['bg-slash', 'bg-contain', 'bg-no-repeat'],
@@ -81,27 +76,66 @@ const OneseoStatus = ({ oneseo }: OneseoStatusType) => {
           >
             {!isGED && schoolName}
           </td>
-          <td colSpan={5} className={cn(tdStyle, 'border-t-0')}>
+          <td colSpan={6} className={cn(tdStyle, 'border-t-0')}>
             {year}년 {month}월 {GraduationEnum[graduationType]}
-          </td>
-          <td className={cn(thStyle, 'border-t-0')}>학번</td>
-          <td
-            className={cn(
-              tdStyle,
-              isGED && ['bg-slash', 'bg-contain', 'bg-no-repeat'],
-              'border-t-0',
-            )}
-          >
-            {!isGED && studentNumber}
           </td>
         </tr>
         <tr>
-          <td className={cn(thStyle)}>주소</td>
+          <td className={cn(thStyle)} colSpan={2}>
+            지원자 학번
+          </td>
           <td
-            colSpan={9}
+            colSpan={2}
+            className={cn(tdStyle, isGED && ['bg-slash', 'bg-contain', 'bg-no-repeat'])}
+          >
+            {!isGED && studentNumber}
+          </td>
+          <td className={cn(thStyle)} colSpan={2}>
+            학교 주소
+          </td>
+          <td
+            colSpan={4}
             className={cn(tdStyle, isGED && ['bg-slash', 'bg-contain', 'bg-no-repeat'])}
           >
             {!isGED && schoolAddress}
+          </td>
+        </tr>
+        <tr>
+          <td className={cn(thStyle, 'leading-tight')} colSpan={3}>
+            원서작성자(담임)
+            <br />
+            성명
+          </td>
+          <td
+            colSpan={2}
+            className={cn(
+              tdStyle,
+              'relative',
+              graduationType !== 'CANDIDATE' && ['bg-slash', 'bg-contain', 'bg-no-repeat'],
+            )}
+          >
+            {graduationType === 'CANDIDATE' && (
+              <>
+                {schoolTeacherName}
+                <span className={cn('absolute', 'right-1', 'top-1/2', '-translate-y-1/2')}>
+                  (인)
+                </span>
+              </>
+            )}
+          </td>
+          <td className={cn(thStyle, 'leading-tight')} colSpan={3}>
+            원서작성자(담임)
+            <br />
+            연락처
+          </td>
+          <td
+            colSpan={2}
+            className={cn(
+              tdStyle,
+              graduationType !== 'CANDIDATE' && ['bg-slash', 'bg-contain', 'bg-no-repeat'],
+            )}
+          >
+            {graduationType === 'CANDIDATE' && schoolTeacherPhoneNumber}
           </td>
         </tr>
         <tr>

--- a/packages/ui/src/components/ApplicationPrintPage/OneseoStatus/index.tsx
+++ b/packages/ui/src/components/ApplicationPrintPage/OneseoStatus/index.tsx
@@ -58,11 +58,9 @@ const OneseoStatus = ({ oneseo }: OneseoStatusType) => {
       <FormColgroup />
       <tbody>
         <tr>
-          <td className={cn(thStyle, 'w-[3%]', 'border-l-0', 'border-t-0')} rowSpan={10}>
+          <td className={cn(thStyle, 'w-[3%]', 'border-l-0', 'border-t-0')} rowSpan={9}>
             지원자 현황
           </td>
-        </tr>
-        <tr>
           <td className={cn(thStyle, 'border-t-0')} colSpan={2} rowSpan={3}>
             출신중학교
           </td>

--- a/packages/ui/src/components/ApplicationPrintPage/PersonalInfoTable/index.tsx
+++ b/packages/ui/src/components/ApplicationPrintPage/PersonalInfoTable/index.tsx
@@ -1,6 +1,8 @@
 import { SexEnum, OneseoStatusType } from '@repo/types';
 import { cn } from '@repo/utils';
 
+import FormColgroup from '../FormColgroup';
+
 const thStyle = 'border border-black bg-[#e9e9e9] ';
 const tdStyle = 'border border-black ';
 
@@ -11,61 +13,60 @@ const PersonalInfoTable = ({ oneseo }: Props) => {
 
   return (
     <table className={cn('w-full', 'border-collapse', 'text-center', 'text-[1.2vh]')}>
+      <FormColgroup />
       <thead>
         <tr>
-          <td className={cn(thStyle, 'w-[3%]', 'border-l-0')} rowSpan={8}>
+          <td className={cn(thStyle, 'border-l-0')} rowSpan={6}>
             인적사항
           </td>
         </tr>
 
         <tr>
-          <td className={cn(thStyle, 'w-[3%]', 'leading-tight')} rowSpan={3}>
+          <td className={cn(thStyle, 'leading-tight')} rowSpan={3}>
             지원자
           </td>
 
           <td className={cn(thStyle)}>성 명</td>
           <td className={cn(tdStyle)}>{oneseo.privacyDetail.name}</td>
 
-          <td className={cn(thStyle, 'w-[3%]', 'leading-none')}>성별</td>
+          <td className={cn(thStyle, 'leading-none')}>성별</td>
           <td className={cn(tdStyle)}>{SexEnum[oneseo.privacyDetail.sex ?? 'MALE']}</td>
 
           <td className={cn(thStyle)}>생년월일</td>
-          <td className={cn(tdStyle)}>
+          <td className={cn(tdStyle)} colSpan={2}>
             {year}년 {month}월 {day}일
           </td>
 
-          <td rowSpan={6} className={cn(tdStyle, 'h-[151px]', 'w-[113px]')}>
+          <td rowSpan={5} colSpan={4} className={cn(tdStyle, 'h-[151px]')}>
             <img
               src={oneseo.privacyDetail.profileImg}
               alt="증명사진"
-              className={cn('w-[113.38582677px]', 'h-[151.18110236px]')}
+              className={cn('mx-auto', 'w-[113.38582677px]', 'h-[151.18110236px]')}
             />
           </td>
         </tr>
 
         <tr>
           <td className={cn(thStyle)}>주 소</td>
-          <td className={cn(tdStyle)} colSpan={5}>
+          <td className={cn(tdStyle)} colSpan={6}>
             {oneseo.privacyDetail.address} {oneseo.privacyDetail.detailAddress}
           </td>
         </tr>
 
         <tr>
           <td className={cn(thStyle)}>핸드폰</td>
-          <td className={cn(tdStyle)} colSpan={5}>
+          <td className={cn(tdStyle)} colSpan={6}>
             {oneseo.privacyDetail.phoneNumber}
           </td>
         </tr>
 
         <tr>
-          <td className={cn(thStyle, 'w-[3%]', 'leading-tight')} rowSpan={2}>
+          <td className={cn(thStyle, 'leading-tight')} rowSpan={2}>
             보호자
           </td>
 
           <td className={cn(thStyle)}>성 명</td>
-          <td className={cn(tdStyle)} colSpan={1}>
-            {oneseo.privacyDetail.guardianName}
-          </td>
+          <td className={cn(tdStyle)}>{oneseo.privacyDetail.guardianName}</td>
 
           <td className={cn(thStyle, 'leading-none')} colSpan={2}>
             지원자와의
@@ -73,55 +74,16 @@ const PersonalInfoTable = ({ oneseo }: Props) => {
             관계
           </td>
 
-          <td className={cn(tdStyle)} colSpan={2}>
+          <td className={cn(tdStyle)} colSpan={3}>
             지원자 {oneseo.privacyDetail.name}의 {oneseo.privacyDetail.relationshipWithGuardian}
           </td>
         </tr>
 
         <tr>
           <td className={cn(thStyle)}>핸드폰</td>
-          <td className={cn(tdStyle)} colSpan={5}>
+          <td className={cn(tdStyle)} colSpan={6}>
             {oneseo.privacyDetail.guardianPhoneNumber}
           </td>
-        </tr>
-
-        <tr>
-          <td className={cn(thStyle)} colSpan={3} rowSpan={6}>
-            원서작성자(담임) 성명
-          </td>
-
-          <td
-            colSpan={2}
-            className={cn([
-              tdStyle,
-              'relative',
-              'text-center',
-              'w-[20%]',
-              oneseo.privacyDetail.graduationType !== 'CANDIDATE' && [
-                'bg-slash',
-                'bg-contain',
-                'bg-no-repeat',
-              ],
-            ])}
-            rowSpan={3}
-          >
-            {oneseo.privacyDetail.graduationType === 'CANDIDATE' && (
-              <>
-                {oneseo.privacyDetail.schoolTeacherName}
-                <span className="absolute right-1 top-1/2 -translate-y-1/2">(인)</span>
-              </>
-            )}
-          </td>
-
-          <td className={cn(thStyle)}>연락처</td>
-
-          {oneseo.privacyDetail.graduationType === 'CANDIDATE' ? (
-            <td className={cn('border-b', 'border-black')}>
-              {oneseo.privacyDetail.schoolTeacherPhoneNumber}
-            </td>
-          ) : (
-            <td className={cn([tdStyle, 'bg-slash', 'bg-contain', 'bg-no-repeat'])} />
-          )}
         </tr>
       </thead>
     </table>

--- a/packages/ui/src/components/ApplicationPrintPage/PersonalInfoTable/index.tsx
+++ b/packages/ui/src/components/ApplicationPrintPage/PersonalInfoTable/index.tsx
@@ -16,12 +16,10 @@ const PersonalInfoTable = ({ oneseo }: Props) => {
       <FormColgroup />
       <thead>
         <tr>
-          <td className={cn(thStyle, 'border-l-0')} rowSpan={6}>
+          <td className={cn(thStyle, 'border-l-0')} rowSpan={5}>
             인적사항
           </td>
-        </tr>
 
-        <tr>
           <td className={cn(thStyle, 'leading-tight')} rowSpan={3}>
             지원자
           </td>

--- a/packages/ui/src/components/ApplicationPrintPage/PersonalInfoTable/index.tsx
+++ b/packages/ui/src/components/ApplicationPrintPage/PersonalInfoTable/index.tsx
@@ -31,29 +31,29 @@ const PersonalInfoTable = ({ oneseo }: Props) => {
           <td className={cn(tdStyle)}>{SexEnum[oneseo.privacyDetail.sex ?? 'MALE']}</td>
 
           <td className={cn(thStyle)}>생년월일</td>
-          <td className={cn(tdStyle)} colSpan={2}>
+          <td className={cn(tdStyle)} colSpan={4}>
             {year}년 {month}월 {day}일
           </td>
 
-          <td rowSpan={5} colSpan={4} className={cn(tdStyle, 'h-[151px]')}>
+          <td rowSpan={5} colSpan={2} className={cn(tdStyle, 'h-[151px]')}>
             <img
               src={oneseo.privacyDetail.profileImg}
               alt="증명사진"
-              className={cn('mx-auto', 'w-[113.38582677px]', 'h-[151.18110236px]')}
+              className={cn('mx-auto', 'max-w-none', 'w-[113.38582677px]', 'h-[151.18110236px]')}
             />
           </td>
         </tr>
 
         <tr>
           <td className={cn(thStyle)}>주 소</td>
-          <td className={cn(tdStyle)} colSpan={6}>
+          <td className={cn(tdStyle)} colSpan={8}>
             {oneseo.privacyDetail.address} {oneseo.privacyDetail.detailAddress}
           </td>
         </tr>
 
         <tr>
           <td className={cn(thStyle)}>핸드폰</td>
-          <td className={cn(tdStyle)} colSpan={6}>
+          <td className={cn(tdStyle)} colSpan={8}>
             {oneseo.privacyDetail.phoneNumber}
           </td>
         </tr>
@@ -72,14 +72,14 @@ const PersonalInfoTable = ({ oneseo }: Props) => {
             관계
           </td>
 
-          <td className={cn(tdStyle)} colSpan={3}>
+          <td className={cn(tdStyle)} colSpan={5}>
             지원자 {oneseo.privacyDetail.name}의 {oneseo.privacyDetail.relationshipWithGuardian}
           </td>
         </tr>
 
         <tr>
           <td className={cn(thStyle)}>핸드폰</td>
-          <td className={cn(tdStyle)} colSpan={6}>
+          <td className={cn(tdStyle)} colSpan={8}>
             {oneseo.privacyDetail.guardianPhoneNumber}
           </td>
         </tr>


### PR DESCRIPTION
## 개요 💡

2027학년도 입학원서 서식 변경사항(작년 대비)을 원서 PDF 출력 화면에 반영합니다.

## 작업내용 ⌨️

- 출신중학교 섹션에 "지원자 학번 / 학교 주소" 행 추가 (기존 "지역명 시·도/시·군·구"에서 교체)
- 출신중학교 섹션에 "원서작성자(담임) 성명 / 연락처" 행 추가 (인적사항 섹션에서 이동, 졸업예정자만 표시 + 도장 로직 유지)
- 인적사항 섹션에서 담임 서명 행 제거
- 서약서(`ApplicationPledge`)에 담임 서명란("담임 : (인)") 추가, 지원자/보호자/담임 서명란 간 세로 간격 조정
- 2차 전형 준비물 안내 문구를 원서 서식과 동일하게 수정
- 인적사항 표와 지원자현황 표가 서로 다른 `<table>`이라 세로선이 어긋나던 문제 수정: 두 표가 공유하는 컬럼 `colgroup`을 `FormColgroup` 컴포넌트로 분리해 재사용


## 스크린샷/동영상 📸
<img width="1798" height="1008" alt="스크린샷 2026-07-17 오후 7 30 19" src="https://github.com/user-attachments/assets/3d4ab7f3-df70-468f-9579-831291535dd8" />


## 관련 이슈 🚨

https://github.com/themoment-team/hellogsm-client-26/issues/426

## 리뷰 요청사항 👀

- `FormColgroup`으로 두 표의 컬럼 그리드를 통일한 방식이 적절한지 확인 부탁드립니다. 
