### PR TITLE
[feat] 전형 일정 하드코딩 날짜 단일 소스 통합, 날짜 변경

### DIFF
--- a/apps/admin/src/pageContainer/TicketPage/index.tsx
+++ b/apps/admin/src/pageContainer/TicketPage/index.tsx
@@ -1,13 +1,7 @@
 'use client';
 
 import { useGetAdmissionTickets } from '@repo/api/hooks';
-import {
-  NEXT_YEAR,
-  passedMemberAnnounceDate,
-  visionCampDate,
-  심층면접시험기간,
-  역량검사시험기간,
-} from '@repo/constants';
+import { ADMISSION_SCHEDULE, NEXT_YEAR } from '@repo/constants';
 import { TicketType } from '@repo/types';
 import { PrintIcon } from '@repo/ui/icons';
 import { Button } from '@repo/ui/shadcn';
@@ -81,7 +75,7 @@ const TicketPage = ({ initialData }: TicketPageProps) => {
                     'font-normal',
                   )}
                 >
-                  {역량검사시험기간}
+                  {ADMISSION_SCHEDULE.competencyEvaluation.period}
                 </td>
 
                 <td rowSpan={7} className={cn('h-[200px]', 'w-[150px]', 'border', 'border-black')}>
@@ -124,7 +118,7 @@ const TicketPage = ({ initialData }: TicketPageProps) => {
                     'font-normal',
                   )}
                 >
-                  {심층면접시험기간}
+                  {ADMISSION_SCHEDULE.inDepthInterview.period}
                 </td>
                 <td
                   rowSpan={1}
@@ -181,7 +175,7 @@ const TicketPage = ({ initialData }: TicketPageProps) => {
                     'font-normal',
                   )}
                 >
-                  {passedMemberAnnounceDate}
+                  {ADMISSION_SCHEDULE.finalAnnouncement.label}
                 </td>
                 <td
                   className={cn(
@@ -229,7 +223,7 @@ const TicketPage = ({ initialData }: TicketPageProps) => {
                   <br />
                   (2) 건강진단서 1부
                   <br />
-                  2025. 11. 05.(수)~ 11. 10.(월) 16:30
+                  {ADMISSION_SCHEDULE.registration.ticketPeriod}
                   <br />
                   (※ 휴무일과 공휴일은 서류 접수하지 않음)
                 </td>
@@ -285,7 +279,7 @@ const TicketPage = ({ initialData }: TicketPageProps) => {
                     'font-normal',
                   )}
                 >
-                  {visionCampDate.startDate} ~ {visionCampDate.endDate} 예정
+                  {ADMISSION_SCHEDULE.visionCamp.start} ~ {ADMISSION_SCHEDULE.visionCamp.end} 예정
                 </td>
                 <td
                   rowSpan={2}
@@ -301,7 +295,7 @@ const TicketPage = ({ initialData }: TicketPageProps) => {
                 >
                   위 사람은 {NEXT_YEAR}학년도 <br /> 본교 신입생 입학전형 지원자임을 확인함.
                   <p className={cn('pr-[0.625rem]', 'text-center', 'font-normal')}>
-                    2025년 10월 31일
+                    {ADMISSION_SCHEDULE.competencyEvaluation.issueDateLabel}
                   </p>
                   <p>광주소프트웨어마이스터고등학교장 [직인생략]</p>
                 </td>

--- a/apps/client/src/components/MainPage/Section1/index.tsx
+++ b/apps/client/src/components/MainPage/Section1/index.tsx
@@ -2,10 +2,10 @@
 
 import { useRouter } from 'next/navigation';
 
+import { ADMISSION_SCHEDULE } from '@repo/constants';
 import { cn, scrollToElement } from '@repo/utils';
 
 import { BottomArrow } from '@/assets';
-import { RECRUITMENT_PERIOD } from '@/constants';
 
 import Video from './Video';
 
@@ -96,7 +96,8 @@ const Section1 = ({ isServerCurrentActive }: { isServerCurrentActive: boolean })
                   'sm:text-[1.25rem]/[1.75rem]',
                 )}
               >
-                접수기간 : {RECRUITMENT_PERIOD.startDate} ~ {RECRUITMENT_PERIOD.endDate}
+                접수기간 : {ADMISSION_SCHEDULE.submission.startLabel} ~{' '}
+                {ADMISSION_SCHEDULE.submission.endLabel}
               </p>
             )}
           </div>

--- a/apps/client/src/components/MainPage/Section2/index.tsx
+++ b/apps/client/src/components/MainPage/Section2/index.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { ADMISSION_SCHEDULE } from '@repo/constants';
 import { cn } from '@repo/utils';
 
 import {
@@ -17,8 +18,8 @@ const stepsData = [
     title: '원서 및 성적 입력',
     date: (
       <>
-        <span className={cn('whitespace-nowrap')}>2025. 10. 20.(월)~</span>
-        <span className={cn('whitespace-nowrap')}>23.(목) 09:00 ~ 16:30</span>
+        <span className={cn('whitespace-nowrap')}>{ADMISSION_SCHEDULE.submission.stepStart}</span>
+        <span className={cn('whitespace-nowrap')}>{ADMISSION_SCHEDULE.submission.stepEnd}</span>
       </>
     ),
     color: 'border-lime-500',
@@ -28,8 +29,8 @@ const stepsData = [
     title: '입학 원서 및 증빙서류 제출',
     date: (
       <>
-        <span className={cn('whitespace-nowrap')}>2025. 10. 20.(월)~</span>
-        <span className={cn('whitespace-nowrap')}>23.(목) 09:00 ~ 16:30</span>
+        <span className={cn('whitespace-nowrap')}>{ADMISSION_SCHEDULE.submission.stepStart}</span>
+        <span className={cn('whitespace-nowrap')}>{ADMISSION_SCHEDULE.submission.stepEnd}</span>
       </>
     ),
     color: 'border-sky-400',
@@ -37,25 +38,25 @@ const stepsData = [
   {
     icon: <Section2Icon3 />,
     title: '1차 전형 합격자 발표',
-    date: '2025. 10. 28.(화) 10:00',
+    date: ADMISSION_SCHEDULE.firstAnnouncement.step,
     color: 'border-sky-600',
   },
   {
     icon: <Section2Icon4 />,
     title: '2차 전형(역량검사)',
-    date: '2025. 10. 31.(금) 14:00-16:30',
+    date: ADMISSION_SCHEDULE.competencyEvaluation.step,
     color: 'border-lime-500',
   },
   {
     icon: <Section2Icon5 />,
     title: '2차 전형(심층면접)',
-    date: '2025. 11. 1.(토) 09:00-16:30',
+    date: ADMISSION_SCHEDULE.inDepthInterview.step,
     color: 'border-sky-600',
   },
   {
     icon: <Section2Icon6 />,
     title: '최종 합격자 발표',
-    date: '2025. 11. 5.(수) 10:00',
+    date: ADMISSION_SCHEDULE.finalAnnouncement.step,
     color: 'border-lime-500',
   },
   {
@@ -63,12 +64,10 @@ const stepsData = [
     title: '합격자 등록(서류 제출)',
     date: (
       <>
-        <span className={cn('whitespace-nowrap')}>2025. 11. 5.(수) ~</span>
-        <span className={cn('whitespace-nowrap')}>11. 10.(월) 16:30</span>
+        <span className={cn('whitespace-nowrap')}>{ADMISSION_SCHEDULE.registration.stepStart}</span>
+        <span className={cn('whitespace-nowrap')}>{ADMISSION_SCHEDULE.registration.stepEnd}</span>
         <br />
-        <span className={cn('whitespace-nowrap')}>
-          (건강검진 관련서류 제출: 11. 10.(월) 16:30까지)
-        </span>
+        <span className={cn('whitespace-nowrap')}>{ADMISSION_SCHEDULE.registration.stepNote}</span>
       </>
     ),
     color: 'border-sky-400',

--- a/apps/client/src/components/MainPage/Section3/index.tsx
+++ b/apps/client/src/components/MainPage/Section3/index.tsx
@@ -2,10 +2,10 @@
 
 import Link from 'next/link';
 
+import { ADMISSION_SCHEDULE } from '@repo/constants';
 import { cn } from '@repo/utils';
 
 import * as I from '@/assets';
-import { RECRUITMENT_PERIOD } from '@/constants';
 
 const buttonStyle = [
   'font-semibold',
@@ -55,7 +55,8 @@ const Section3 = ({ isServerHealthy }: Section3Props) => {
             2026 신입생 모집
           </h1>
           <p className={cn('mb-0', 'lg:mb-8', 'mt-[1rem]', 'hidden', 'smx:flex', 'text-gray-500')}>
-            접수 기간: {RECRUITMENT_PERIOD.startDate} ~ {RECRUITMENT_PERIOD.endDate}
+            접수 기간: {ADMISSION_SCHEDULE.submission.startLabel} ~{' '}
+            {ADMISSION_SCHEDULE.submission.endLabel}
           </p>
           <Link
             href="/guide"

--- a/apps/client/src/constants/date.ts
+++ b/apps/client/src/constants/date.ts
@@ -1,4 +1,0 @@
-export const RECRUITMENT_PERIOD = {
-  startDate: '2025.10.20. (월) 오전 9시',
-  endDate: '2025.10.23. (목) 오후 4시 30분',
-} as const;

--- a/apps/client/src/constants/index.ts
+++ b/apps/client/src/constants/index.ts
@@ -1,1 +1,0 @@
-export * from './date';

--- a/packages/constants/src/date.ts
+++ b/packages/constants/src/date.ts
@@ -12,64 +12,64 @@ export const ADMISSION_SCHEDULE = {
   /** 원서 접수 기간 */
   submission: {
     /** 메인 히어로·모집 안내 표기 (client Section1 / Section3) */
-    startLabel: '2025.10.20. (월) 오전 9시',
-    endLabel: '2025.10.23. (목) 오후 4시 30분',
+    startLabel: '2026.10.19. (월) 오전 9시',
+    endLabel: '2026.10.22. (목) 오후 5시',
     /** 모집절차 스텝 표기 (client Section2) — 시작/종료 라벨 분리 노출 */
-    stepStart: '2025. 10. 20.(월)~',
-    stepEnd: '23.(목) 09:00 ~ 16:30',
+    stepStart: '2026. 10. 19.(월)~',
+    stepEnd: '22.(목) 09:00 ~ 17:00',
   },
 
   /** 1차 전형 합격자 발표 */
   firstAnnouncement: {
     /** 모집절차 스텝 표기 (client Section2) */
-    step: '2025. 10. 28.(화) 10:00',
+    step: '2025. 10. 27.(화) 10:00',
   },
 
   /** 2차 전형 — 역량검사 */
   competencyEvaluation: {
     /** ISO 날짜 (로직/판별용) */
-    date: '2025-10-31',
+    date: '2026-10-30',
     /** 수험표 표기 (admin TicketPage) */
-    period: '2025. 10. 31.(금) 14:00 ~ 16:30',
+    period: '2026. 10. 30.(금) 14:00 ~ 16:30',
     /** 모집절차 스텝 표기 (client Section2) */
-    step: '2025. 10. 31.(금) 14:00-16:30',
+    step: '2026. 10. 30.(금) 14:00-16:30',
     /** 확인서 발급일 표기 (admin TicketPage) */
-    issueDateLabel: '2025년 10월 31일',
+    issueDateLabel: '2026년 10월 30일',
   },
 
   /** 2차 전형 — 심층면접 */
   inDepthInterview: {
     /** ISO 날짜 (로직/판별용) */
-    date: '2025-11-01',
+    date: '2026-10-31',
     /** 수험표 표기 (admin TicketPage) */
-    period: '2025. 11. 01.(토) 09:00 ~ 16:30',
+    period: '2026. 10. 31.(토) 09:00 ~ 16:30',
     /** 모집절차 스텝 표기 (client Section2) */
-    step: '2025. 11. 1.(토) 09:00-16:30',
+    step: '2026. 10. 31.(토) 09:00-16:30',
   },
 
   /** 최종 합격자 발표 */
   finalAnnouncement: {
     /** 수험표 표기 (admin TicketPage) */
-    label: '2025. 11. 05.(수) 10:00',
+    label: '2026. 11. 04.(수) 10:00',
     /** 모집절차 스텝 표기 (client Section2) */
-    step: '2025. 11. 5.(수) 10:00',
+    step: '2026. 11. 4.(수) 10:00',
   },
 
   /** 합격자 등록(서류 제출) */
   registration: {
     /** 모집절차 스텝 표기 (client Section2) — 시작/종료/비고 분리 노출 */
-    stepStart: '2025. 11. 5.(수) ~',
-    stepEnd: '11. 10.(월) 16:30',
-    stepNote: '(건강검진 관련서류 제출: 11. 10.(월) 16:30까지)',
+    stepStart: '2026. 11. 4.(수) ~',
+    stepEnd: '11. 9.(월) 17:00',
+    stepNote: '(건강검진 관련서류 제출: 11. 9.(월) 17:00까지)',
     /** 수험표 표기 (admin TicketPage) */
-    ticketPeriod: '2025. 11. 05.(수)~ 11. 10.(월) 16:30',
+    ticketPeriod: '2026. 11. 04.(수)~ 11. 9.(월) 17:00',
   },
 
   /** 비전캠프 */
   visionCamp: {
     /** admin TicketPage */
-    start: '2026. 01. 14.(수)',
-    end: '2026. 01. 16.(금)',
+    start: '2027. 01. 13.(수)',
+    end: '2027. 01. 15.(금)',
   },
 } as const;
 

--- a/packages/constants/src/date.ts
+++ b/packages/constants/src/date.ts
@@ -1,25 +1,77 @@
-export const RECRUITMENT_PERIOD = {
-  startDate: '2024.10.10.',
-  endDate: '오전 9시 ~ 5시',
+/**
+ * 전형 일정 (화면 표기용 단일 소스)
+ *
+ * 백엔드 서버는 서비스 운영 기간에만 켜두고 그 외 기간에는 내려두기 때문에,
+ * 서버(`/date` API)가 없어도 화면에 일정을 노출할 수 있도록 프론트에서 하드코딩으로 관리합니다.
+ *
+ * ⚠️ 매년 신입생 모집 일정이 바뀔 때는 "이 파일만" 수정하면 client·admin 전 화면에 반영됩니다.
+ *    한 이벤트를 여러 화면이 서로 다른 포맷으로 노출하므로, 갱신 시 해당 이벤트 블록의
+ *    모든 값을 함께 수정하세요. (포맷이 화면마다 다른 것은 기존 디자인을 유지하기 위함입니다.)
+ */
+export const ADMISSION_SCHEDULE = {
+  /** 원서 접수 기간 */
+  submission: {
+    /** 메인 히어로·모집 안내 표기 (client Section1 / Section3) */
+    startLabel: '2025.10.20. (월) 오전 9시',
+    endLabel: '2025.10.23. (목) 오후 4시 30분',
+    /** 모집절차 스텝 표기 (client Section2) — 시작/종료 라벨 분리 노출 */
+    stepStart: '2025. 10. 20.(월)~',
+    stepEnd: '23.(목) 09:00 ~ 16:30',
+  },
+
+  /** 1차 전형 합격자 발표 */
+  firstAnnouncement: {
+    /** 모집절차 스텝 표기 (client Section2) */
+    step: '2025. 10. 28.(화) 10:00',
+  },
+
+  /** 2차 전형 — 역량검사 */
+  competencyEvaluation: {
+    /** ISO 날짜 (로직/판별용) */
+    date: '2025-10-31',
+    /** 수험표 표기 (admin TicketPage) */
+    period: '2025. 10. 31.(금) 14:00 ~ 16:30',
+    /** 모집절차 스텝 표기 (client Section2) */
+    step: '2025. 10. 31.(금) 14:00-16:30',
+    /** 확인서 발급일 표기 (admin TicketPage) */
+    issueDateLabel: '2025년 10월 31일',
+  },
+
+  /** 2차 전형 — 심층면접 */
+  inDepthInterview: {
+    /** ISO 날짜 (로직/판별용) */
+    date: '2025-11-01',
+    /** 수험표 표기 (admin TicketPage) */
+    period: '2025. 11. 01.(토) 09:00 ~ 16:30',
+    /** 모집절차 스텝 표기 (client Section2) */
+    step: '2025. 11. 1.(토) 09:00-16:30',
+  },
+
+  /** 최종 합격자 발표 */
+  finalAnnouncement: {
+    /** 수험표 표기 (admin TicketPage) */
+    label: '2025. 11. 05.(수) 10:00',
+    /** 모집절차 스텝 표기 (client Section2) */
+    step: '2025. 11. 5.(수) 10:00',
+  },
+
+  /** 합격자 등록(서류 제출) */
+  registration: {
+    /** 모집절차 스텝 표기 (client Section2) — 시작/종료/비고 분리 노출 */
+    stepStart: '2025. 11. 5.(수) ~',
+    stepEnd: '11. 10.(월) 16:30',
+    stepNote: '(건강검진 관련서류 제출: 11. 10.(월) 16:30까지)',
+    /** 수험표 표기 (admin TicketPage) */
+    ticketPeriod: '2025. 11. 05.(수)~ 11. 10.(월) 16:30',
+  },
+
+  /** 비전캠프 */
+  visionCamp: {
+    /** admin TicketPage */
+    start: '2026. 01. 14.(수)',
+    end: '2026. 01. 16.(금)',
+  },
 } as const;
 
-// TODO 정확한 날짜 확인 후 수정
-export const 역량검사일자 = '2025-10-31';
-export const 심층면접일자 = '2025-11-01';
-export const 역량검사시험기간 = '2025. 10. 31.(금) 14:00 ~ 16:30';
-export const 심층면접시험기간 = '2025. 11. 01.(토) 09:00 ~ 16:30';
-
-// TODO 정확한 날짜 확인 후 수정
-export const visionCampDate = {
-  startDate: '2026. 01. 14.(수)',
-  endDate: '2026. 01. 16.(금)',
-};
-
-// TODO 정확한 날짜 확인 후 수정
-export const passedMemberAnnounceDate = '2025. 11. 05.(수) 10:00';
-export const passedMemberSubmitDate = {
-  startDate: '2025. 11. 1.(수)',
-  endDate: '2025. 11. 6.(월)',
-};
 export const CURRENT_YEAR = new Date().getFullYear();
 export const NEXT_YEAR = CURRENT_YEAR + 1;


### PR DESCRIPTION
## 개요 💡

백엔드 서버는 서비스 운영 기간에만 켜두고 비운영 기간에는 내려두기 때문에, 전형 일정은 프론트에서 하드코딩으로 표기해야 합니다. 그런데 표기용 날짜가 client·admin 여러 파일에 흩어져 있어, 매년 신입생 모집 일정을 갱신할 때 일부 파일을 놓치기 쉬운 구조였습니다.

이 PR은 흩어진 표기용 날짜를 `packages/constants`의 단일 소스(`ADMISSION_SCHEDULE`)로 통합해, **매년 이 파일 하나만 수정하면** client/admin 전 화면 일정이 갱신되도록 개선합니다.

## 작업내용 ⌨️

- `packages/constants/src/date.ts`를 이벤트별 구조화 객체 `ADMISSION_SCHEDULE`(접수/1차발표/역량검사/심층면접/최종발표/등록/비전캠프)로 재구성
- 중복된 `RECRUITMENT_PERIOD`(`apps/client/src/constants`)와 미사용 상수(`역량검사일자`, `심층면접일자`, `passedMemberSubmitDate`) 제거 → 관련 파일 삭제
- client `MainPage/Section1`·`Section2`·`Section3`의 하드코딩 날짜를 상수 참조로 교체
- admin `TicketPage`의 상수 참조 + 직접 하드코딩(수험표 서류제출 기간, 확인서 발급일)을 모두 상수 참조로 교체

## 리뷰 요청사항 👀

- 화면에 노출되는 날짜 **텍스트 출력은 기존과 동일**하게 유지했습니다. 포맷이 화면마다 다른 부분(예: `5일` vs `05일`, `14:00-16:30` vs `14:00 ~ 16:30`)도 기존 디자인 보존을 위해 그대로 두었는데, 이번에 하나로 통일하는 게 좋을지 의견 부탁드립니다.
- 격리 환경 제약으로 로컬에서 `tsc`/`eslint`를 돌리지 못했습니다. CI 결과 확인 부탁드립니다.
- 서버(`/date` API) 기반 접근 차단 판별 로직은 이번 변경과 무관하여 건드리지 않았습니다.
