### PR TITLE
[fix] 푸터 정책 링크를 학교 홈페이지로 변경

### DIFF
--- a/apps/client/src/components/Footer/index.tsx
+++ b/apps/client/src/components/Footer/index.tsx
@@ -6,19 +6,19 @@ import { FooterGSMLogo } from '@/assets';
 const LINKS = [
   {
     text: '개인정보처리방침',
-    link: 'https://official.hellogsm.kr/policy/privacy',
+    link: 'https://gsm.gen.hs.kr:453/sub/page.php?page_code=help_08',
   },
   {
     text: '영상정보처리기기운영·관리방침',
-    link: 'https://official.hellogsm.kr/policy/cctv',
+    link: 'https://gsm.gen.hs.kr:453/sub/page.php?page_code=help_09',
   },
   {
     text: '저작권신고 및 보호규정',
-    link: 'https://official.hellogsm.kr/policy/copyright',
+    link: 'https://gsm.gen.hs.kr:453/sub/page.php?page_code=help_10',
   },
   {
     text: '찾아오시는 길',
-    link: 'https://official.hellogsm.kr/about/location',
+    link: 'https://gsm.gen.hs.kr:453/sub/page.php?page_code=info_07',
   },
 ] as const;
 


### PR DESCRIPTION
## 개요 💡

푸터의 정책·안내 링크가 official.hellogsm.kr을 가리키고 있었으나,
해당 문서의 원본 출처인 광주소프트웨어마이스터고 공식 홈페이지로 연결되도록 변경합니다.

## 작업내용 ⌨️

`apps/client/src/components/Footer/index.tsx`의 `LINKS` 4건 URL 교체

| 항목 | 변경 전 | 변경 후 |
| --- | --- | --- |
| 개인정보처리방침 | official.hellogsm.kr/policy/privacy | gsm.gen.hs.kr:453/sub/page.php?page_code=help_08 |
| 영상정보처리기기운영·관리방침 | official.hellogsm.kr/policy/cctv | gsm.gen.hs.kr:453/sub/page.php?page_code=help_09 |
| 저작권신고 및 보호규정 | official.hellogsm.kr/policy/copyright | gsm.gen.hs.kr:453/sub/page.php?page_code=help_10 |
| 찾아오시는 길 | official.hellogsm.kr/about/location | gsm.gen.hs.kr:453/sub/page.php?page_code=info_07 |

## 리뷰 요청사항 👀

- 4개 링크의 연결 대상 페이지가 각 항목과 맞는지 확인 부탁드립니다.
