### PR TITLE
[fix] React Compiler stale watch로 원서 폼 선택이 화면에 반영되지 않던 문제 수정

### DIFF
--- a/packages/eslint-config/next.js
+++ b/packages/eslint-config/next.js
@@ -4,7 +4,7 @@ import reactHooks from 'eslint-plugin-react-hooks';
 import globals from 'globals';
 
 import { baseConfig } from './base.js';
-import { reactHooksCompilerRules } from './react-hooks-compiler.js';
+import { reactHooksCompilerRules, rhfWatchPropRules } from './react-hooks-compiler.js';
 
 /** @type {import("eslint").Linter.Config[]} */
 export const nextJsConfig = [
@@ -40,6 +40,7 @@ export const nextJsConfig = [
       'react/prop-types': 'off',
       'react/no-unknown-property': ['error', { ignore: ['jsx', 'global'] }],
       ...reactHooksCompilerRules,
+      ...rhfWatchPropRules,
     },
   },
 ];

--- a/packages/eslint-config/react-hooks-compiler.js
+++ b/packages/eslint-config/react-hooks-compiler.js
@@ -24,3 +24,26 @@ export const reactHooksCompilerRules = {
   'react-hooks/config': 'error',
   'react-hooks/gating': 'error',
 };
+
+/**
+ * react-hooks/incompatible-library가 못 잡는 구멍을 메우는 보완 룰.
+ *
+ * 저 룰은 `useForm().watch` 형태를 어휘적으로만 탐지해서, watch를 props로 자식에
+ * 내려주면 탐지되지 않는다. 그 경로로 남아 있던 Step1~4·하위 폼 8개 컴포넌트에서
+ * 컴파일러가 watch() 호출 결과와 그것을 쓰는 JSX 스코프를 통째로 메모이즈해
+ * 라디오·셀렉트 선택이 화면에 반영되지 않는 버그가 났다(2026-07-27).
+ *
+ * watch는 렌더마다 다른 값을 반환하는 비순수 함수이므로 props 경계를 넘겨선 안 된다.
+ * control을 넘기고 자식에서 useWatch로 구독하는 것이 RHF 권장 방식이다.
+ */
+export const rhfWatchPropRules = {
+  'no-restricted-syntax': [
+    'error',
+    {
+      selector:
+        'TSPropertySignature TSTypeReference > Identifier[name="UseFormWatch"]',
+      message:
+        'watch를 props로 넘기지 마세요. React Compiler가 비순수 함수인 watch()의 호출 결과를 메모이즈해 값이 갱신되지 않습니다. control을 넘기고 자식에서 useWatch({ control, name })로 구독하거나, 구독이 불필요하면 getValues()를 쓰세요.',
+    },
+  ],
+};

--- a/packages/eslint-config/react-internal.js
+++ b/packages/eslint-config/react-internal.js
@@ -3,7 +3,7 @@ import reactHooks from 'eslint-plugin-react-hooks';
 import globals from 'globals';
 
 import { baseConfig } from './base.js';
-import { reactHooksCompilerRules } from './react-hooks-compiler.js';
+import { reactHooksCompilerRules, rhfWatchPropRules } from './react-hooks-compiler.js';
 
 /** @type {import("eslint").Linter.Config[]} */
 export const reactInternalConfig = [
@@ -26,6 +26,7 @@ export const reactInternalConfig = [
       'react/react-in-jsx-scope': 'off',
       'react/prop-types': 'off',
       ...reactHooksCompilerRules,
+      ...rhfWatchPropRules,
     },
   },
 ];

--- a/packages/ui/src/components/UploadPhoto/index.tsx
+++ b/packages/ui/src/components/UploadPhoto/index.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { FieldErrors, UseFormSetValue, UseFormWatch } from 'react-hook-form';
+import { Control, FieldErrors, UseFormSetValue, useWatch } from 'react-hook-form';
 
 import { usePostImage } from '@repo/api/hooks';
 import { useModalStore } from '@repo/store';
@@ -12,14 +12,15 @@ import { UploadIcon } from '../../icons';
 
 interface UploadPhotoProps {
   setValue: UseFormSetValue<Step1FormType>;
-  watch: UseFormWatch<Step1FormType>;
+  control: Control<Step1FormType>;
   errors: FieldErrors<Step1FormType>;
   showError: boolean;
 }
 
-const UploadPhoto = ({ setValue, watch, errors, showError }: UploadPhotoProps) => {
+const UploadPhoto = ({ setValue, control, errors, showError }: UploadPhotoProps) => {
   const { setImageUploadSizeLimitModal } = useModalStore();
-  const profileImg = watch('profileImg');
+  // 렌더 중 구독은 watch() 대신 useWatch 사용 (React Compiler 호환)
+  const profileImg = useWatch({ control, name: 'profileImg' });
 
   const { mutate: postImage, isSuccess } = usePostImage({
     onSuccess: ({ url }) => setValue('profileImg', url),

--- a/packages/ui/src/components/form/ArtPhysicalForm/index.tsx
+++ b/packages/ui/src/components/form/ArtPhysicalForm/index.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useEffect } from 'react';
-import { UseFormSetValue, UseFormWatch } from 'react-hook-form';
+import { Control, UseFormSetValue, useWatch } from 'react-hook-form';
 
 import {
   ART_PHYSICAL_SCORE_VALUES,
@@ -16,7 +16,7 @@ import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '.
 interface ArtPhysicalFormProps {
   freeSemester: FreeSemesterValueEnum | null;
   setValue: UseFormSetValue<Step4FormType>;
-  watch: UseFormWatch<Step4FormType>;
+  control: Control<Step4FormType>;
   isFreeGrade: boolean;
   isFreeSemester: boolean;
   isGraduate: boolean;
@@ -67,9 +67,13 @@ const ArtPhysicalForm = ({
   isFreeSemester,
   isGraduate,
   graduationType,
-  watch,
+  control,
   showError,
 }: ArtPhysicalFormProps) => {
+  // 렌더 중 구독은 watch() 대신 useWatch 사용 (React Compiler 호환)
+  // 훅은 map 안에서 호출할 수 없으므로 배열 전체를 한 번 구독하고 인덱싱한다
+  const artsPhysicalAchievement = useWatch({ control, name: 'artsPhysicalAchievement' });
+
   const artPhysicalArray = getArtPhysicalArray({
     graduationType,
     isFreeSemester,
@@ -133,7 +137,7 @@ const ArtPhysicalForm = ({
           </div>
           <div className={cn('flex')}>
             {registerIndexList.map((registerIndex) => {
-              const score = watch(`artsPhysicalAchievement.${registerIndex}`);
+              const score = artsPhysicalAchievement?.[registerIndex];
               const isDisabled = disabledIndices.includes(registerIndex);
 
               return (
@@ -178,9 +182,7 @@ const ArtPhysicalForm = ({
                           'px-[0.5rem]',
                           'border-slate-300',
                           isGraduate ? 'w-[7.34rem]' : isFreeGrade ? 'w-[10.46rem]' : 'w-[5.47rem]',
-                          watch(`artsPhysicalAchievement.${registerIndex}`) === undefined &&
-                            showError &&
-                            '!border-red-600',
+                          score === undefined && showError && '!border-red-600',
                         ])}
                       >
                         <SelectValue placeholder="성적 선택" />

--- a/packages/ui/src/components/form/FreeGradeForm/index.tsx
+++ b/packages/ui/src/components/form/FreeGradeForm/index.tsx
@@ -8,8 +8,8 @@ import {
   UseFormGetValues,
   UseFormRegister,
   UseFormSetValue,
-  UseFormWatch,
   get,
+  useWatch,
 } from 'react-hook-form';
 
 import { ACHIEVEMENT_FIELD_LIST, GENERAL_SCORE_VALUES, GENERAL_SUBJECTS } from '@repo/constants';
@@ -25,7 +25,6 @@ interface FreeGradeFormProps {
   control: Control<Step4FormType>;
   setValue: UseFormSetValue<Step4FormType>;
   register: UseFormRegister<Step4FormType>;
-  watch: UseFormWatch<Step4FormType>;
   handleDeleteSubjectClick: (idx: number) => void;
   errors: FieldErrors<Step4FormType>;
   achievementList: AchievementType[];
@@ -60,7 +59,7 @@ const FreeGradeForm = ({
   subjectArray,
   setValue,
   register,
-  watch,
+  control,
   handleDeleteSubjectClick,
   errors,
   achievementList,
@@ -69,13 +68,17 @@ const FreeGradeForm = ({
   getValues,
   validateForm,
 }: FreeGradeFormProps) => {
+  // 렌더 중 구독은 watch() 대신 useWatch 사용 (React Compiler 호환)
+  // 훅은 map 안에서 호출할 수 없으므로 학기별 배열 전체를 한 번 구독하고 인덱싱한다
+  const achievements = useWatch({ control, name: ACHIEVEMENT_FIELD_LIST });
+
   useEffect(() => {
     setTimeout(
       () =>
         ACHIEVEMENT_FIELD_LIST.forEach((field) => {
           const hasField = achievementList.some((freeGrade) => freeGrade.field === field);
           if (hasField) {
-            setValue(field, watch(field) || []);
+            setValue(field, getValues(field) || []);
           } else {
             setValue(field, null);
           }
@@ -155,7 +158,7 @@ const FreeGradeForm = ({
             </div>
             <div className={cn('flex')}>
               {achievementList.map(({ field }) => {
-                const score = watch(`${field}.${idx}`);
+                const score = achievements[ACHIEVEMENT_FIELD_LIST.indexOf(field)]?.[idx];
 
                 const subjectHasError = score === undefined || score === null;
 

--- a/packages/ui/src/components/form/FreeSemesterForm/index.tsx
+++ b/packages/ui/src/components/form/FreeSemesterForm/index.tsx
@@ -3,12 +3,13 @@
 import { XIcon } from 'lucide-react';
 import { useEffect } from 'react';
 import {
+  Control,
   FieldErrors,
   UseFormGetValues,
   UseFormRegister,
   UseFormSetValue,
-  UseFormWatch,
   get,
+  useWatch,
 } from 'react-hook-form';
 
 import { ACHIEVEMENT_FIELD_LIST, GENERAL_SCORE_VALUES, GENERAL_SUBJECTS } from '@repo/constants';
@@ -24,7 +25,7 @@ interface FreeSemesterFormProps {
   subjectArray: string[];
   setValue: UseFormSetValue<Step4FormType>;
   register: UseFormRegister<Step4FormType>;
-  watch: UseFormWatch<Step4FormType>;
+  control: Control<Step4FormType>;
   handleDeleteSubjectClick: (idx: number) => void;
   freeSemester: FreeSemesterValueEnum | null;
   achievementList: AchievementType[];
@@ -84,7 +85,7 @@ const FreeSemesterForm = ({
   register,
   subjectArray,
   setValue,
-  watch,
+  control,
   handleDeleteSubjectClick,
   freeSemester,
   achievementList,
@@ -94,6 +95,10 @@ const FreeSemesterForm = ({
   getValues,
   validateForm,
 }: FreeSemesterFormProps) => {
+  // 렌더 중 구독은 watch() 대신 useWatch 사용 (React Compiler 호환)
+  // 훅은 map 안에서 호출할 수 없으므로 학기별 배열 전체를 한 번 구독하고 인덱싱한다
+  const achievements = useWatch({ control, name: ACHIEVEMENT_FIELD_LIST });
+
   useEffect(() => {
     setTimeout(
       () =>
@@ -102,7 +107,7 @@ const FreeSemesterForm = ({
             achievementList.some((freeGrade) => freeGrade.field === field) &&
             !(freeSemester && field === freeSemesterToAchievementField[freeSemester])
           ) {
-            setValue(field, watch(field) || []);
+            setValue(field, getValues(field) || []);
           } else {
             setValue(field, null);
           }
@@ -116,7 +121,7 @@ const FreeSemesterForm = ({
       if (freeSemester && field === freeSemesterToAchievementField[freeSemester]) {
         setValue(field, null);
       } else {
-        setValue(field, watch(field) || undefined!);
+        setValue(field, getValues(field) || undefined!);
       }
     });
   }, [freeSemester]);
@@ -237,7 +242,7 @@ const FreeSemesterForm = ({
             </div>
             <div className={cn('flex', 'items-center')}>
               {achievementList.map(({ value, field }) => {
-                const score = watch(`${field}.${idx}`);
+                const score = achievements[ACHIEVEMENT_FIELD_LIST.indexOf(field)]?.[idx];
 
                 const subjectHasError = score === undefined || score === null;
                 const isSubjectError = subjectHasError && showError && '!border-red-600';

--- a/packages/ui/src/components/register/Step1Register/index.tsx
+++ b/packages/ui/src/components/register/Step1Register/index.tsx
@@ -3,11 +3,12 @@
 import { useEffect } from 'react';
 import { Address, useDaumPostcodePopup } from 'react-daum-postcode';
 import {
+  Control,
   UseFormRegister,
   UseFormSetValue,
   UseFormTrigger,
-  UseFormWatch,
   FormState,
+  useWatch,
 } from 'react-hook-form';
 
 import { SexValueEnum, Step1FormType } from '@repo/types';
@@ -30,7 +31,7 @@ interface Step1RegisterProps {
   phoneNumber: string;
   register: UseFormRegister<Step1FormType>;
   setValue: UseFormSetValue<Step1FormType>;
-  watch: UseFormWatch<Step1FormType>;
+  control: Control<Step1FormType>;
   trigger: UseFormTrigger<Step1FormType>;
   formState: FormState<Step1FormType>;
   showError: boolean;
@@ -44,14 +45,16 @@ const Step1Register = ({
   phoneNumber,
   register,
   setValue,
-  watch,
+  control,
   trigger,
   formState: { errors },
   showError,
 }: Step1RegisterProps) => {
   const daumPostCode = useDaumPostcodePopup();
 
-  const birth = watch('birth') || '';
+  // 렌더 중 구독은 watch() 대신 useWatch 사용 (React Compiler 호환)
+  const birth = useWatch({ control, name: 'birth' }) || '';
+  const sex = useWatch({ control, name: 'sex' });
   const [birthYear, birthMonth, birthDay] = birth.split('-');
 
   const sexList = [
@@ -142,7 +145,7 @@ const Step1Register = ({
 
       <div className={cn('flex', 'items-end', 'gap-[3rem]')}>
         <div className={cn('flex', 'w-[29.75rem]', 'flex-col', 'items-start', 'gap-[2rem]')}>
-          <UploadPhoto setValue={setValue} watch={watch} errors={errors} showError={showError} />
+          <UploadPhoto setValue={setValue} control={control} errors={errors} showError={showError} />
           <CustomFormItem text={'이름'} className={cn('gap-1')} required={true} fullWidth={true}>
             <Input
               {...register('name')}
@@ -224,7 +227,7 @@ const Step1Register = ({
             title={'성별'}
             list={sexList}
             required={true}
-            selectedValue={watch('sex') || ''}
+            selectedValue={sex || ''}
             handleOptionClick={(value) =>
               setValue('sex', value as 'MALE' | 'FEMALE', {
                 shouldValidate: true,

--- a/packages/ui/src/components/register/Step2Register/index.tsx
+++ b/packages/ui/src/components/register/Step2Register/index.tsx
@@ -2,12 +2,14 @@
 
 import { useEffect } from 'react';
 import {
+  Control,
   FormState,
+  UseFormGetValues,
   UseFormRegister,
   UseFormReset,
   UseFormSetValue,
   UseFormTrigger,
-  UseFormWatch,
+  useWatch,
 } from 'react-hook-form';
 
 import { CURRENT_YEAR, NEXT_YEAR } from '@repo/constants';
@@ -34,7 +36,8 @@ import {
 interface Step2RegisterProps {
   register: UseFormRegister<Step2FormType>;
   setValue: UseFormSetValue<Step2FormType>;
-  watch: UseFormWatch<Step2FormType>;
+  control: Control<Step2FormType>;
+  getValues: UseFormGetValues<Step2FormType>;
   reset: UseFormReset<Step2FormType>;
   trigger: UseFormTrigger<Step2FormType>;
   formState: FormState<Step2FormType>;
@@ -80,7 +83,8 @@ const majorIntroductions = [
 const Step2Register = ({
   register,
   setValue,
-  watch,
+  control,
+  getValues,
   reset,
   trigger,
   formState: { errors },
@@ -92,13 +96,27 @@ const Step2Register = ({
     'thirdDesiredMajor',
   ];
 
-  const year = watch('graduationDate').split('-')[0];
-  const month = watch('graduationDate').split('-')[1];
-  const classroom = watch('classroom');
-  const number = watch('number');
+  // 렌더 중 구독은 watch() 대신 useWatch 사용 (React Compiler 호환)
+  const graduationDate = useWatch({ control, name: 'graduationDate' });
+  const graduationType = useWatch({ control, name: 'graduationType' });
+  const screening = useWatch({ control, name: 'screening' });
+  const classroom = useWatch({ control, name: 'classroom' });
+  const number = useWatch({ control, name: 'number' });
+  const firstDesiredMajor = useWatch({ control, name: 'firstDesiredMajor' });
+  const secondDesiredMajor = useWatch({ control, name: 'secondDesiredMajor' });
+  const thirdDesiredMajor = useWatch({ control, name: 'thirdDesiredMajor' });
 
-  const isCandidate = watch('graduationType') === GraduationTypeValueEnum.CANDIDATE;
-  const isGED = watch('graduationType') === GraduationTypeValueEnum.GED;
+  const majorValueMap: Record<MajorFieldType, DesireMajorValueEnum | undefined | null> = {
+    firstDesiredMajor,
+    secondDesiredMajor,
+    thirdDesiredMajor,
+  };
+
+  const year = graduationDate.split('-')[0];
+  const month = graduationDate.split('-')[1];
+
+  const isCandidate = graduationType === GraduationTypeValueEnum.CANDIDATE;
+  const isGED = graduationType === GraduationTypeValueEnum.GED;
 
   const START_YEAR = isCandidate ? NEXT_YEAR : CURRENT_YEAR;
   const PERMIT_YEAR = isCandidate ? 1 : 5;
@@ -126,7 +144,7 @@ const Step2Register = ({
       setValue('studentNumber', null);
       setValue('classroom', '');
       setValue('number', '');
-    } else if (!watch('schoolName')) {
+    } else if (!getValues('schoolName')) {
       setValue('schoolName', '');
       setValue('schoolAddress', '');
       setValue('studentNumber', '');
@@ -152,7 +170,7 @@ const Step2Register = ({
       case 'firstDesiredMajor':
         setValue('firstDesiredMajor', value);
         reset(
-          { ...watch(), secondDesiredMajor: undefined, thirdDesiredMajor: undefined },
+          { ...getValues(), secondDesiredMajor: undefined, thirdDesiredMajor: undefined },
           { keepErrors: true, keepIsSubmitted: true },
         );
 
@@ -161,7 +179,7 @@ const Step2Register = ({
       case 'secondDesiredMajor':
         setValue('secondDesiredMajor', value);
         reset(
-          { ...watch(), thirdDesiredMajor: undefined },
+          { ...getValues(), thirdDesiredMajor: undefined },
           { keepErrors: true, keepIsSubmitted: true },
         );
 
@@ -184,18 +202,18 @@ const Step2Register = ({
   const hasFirstMajorError =
     showError &&
     errors.firstDesiredMajor &&
-    (watch('firstDesiredMajor') === undefined || watch('firstDesiredMajor') === null);
+    (firstDesiredMajor === undefined || firstDesiredMajor === null);
   const hasSecondMajorError =
     showError &&
     errors.secondDesiredMajor &&
-    (watch('secondDesiredMajor') === undefined || watch('secondDesiredMajor') === null);
+    (secondDesiredMajor === undefined || secondDesiredMajor === null);
   const hasThirdMajorError =
     showError &&
     errors.thirdDesiredMajor &&
-    (watch('thirdDesiredMajor') === undefined || watch('thirdDesiredMajor') === null);
+    (thirdDesiredMajor === undefined || thirdDesiredMajor === null);
 
   useEffect(() => {
-    if (!isGED && watch('schoolName') === null) {
+    if (!isGED && getValues('schoolName') === null) {
       setValue('schoolName', '');
       setValue('schoolAddress', '');
     }
@@ -227,7 +245,7 @@ const Step2Register = ({
           <RadioButton<GraduationTypeValueEnum>
             title={'지원자 유형'}
             list={[...graduationTypeList]}
-            selectedValue={watch('graduationType')}
+            selectedValue={graduationType}
             handleOptionClick={handleGraduationTypeOptionClick}
             error={showError}
             required
@@ -359,7 +377,7 @@ const Step2Register = ({
             title={'전형'}
             list={[...screeningList]}
             required
-            selectedValue={watch('screening')}
+            selectedValue={screening}
             handleOptionClick={(value) => setValue('screening', value)}
             error={showError}
           />
@@ -375,8 +393,8 @@ const Step2Register = ({
                   {majorFieldList.map((fieldName, index) => {
                     const desiredSequence = index + 1;
                     const selectedValues = [
-                      desiredSequence > 1 && watch('firstDesiredMajor'),
-                      desiredSequence > 2 && watch('secondDesiredMajor'),
+                      desiredSequence > 1 && firstDesiredMajor,
+                      desiredSequence > 2 && secondDesiredMajor,
                     ].filter((value) => typeof value === 'string');
                     const filteredMajorList = majorList.filter(
                       ({ value }) => !selectedValues.includes(value),
@@ -385,7 +403,7 @@ const Step2Register = ({
                     return (
                       <Select
                         key={fieldName}
-                        value={watch(fieldName) || ''}
+                        value={majorValueMap[fieldName] || ''}
                         onValueChange={(value) =>
                           // TODO string 값으로 와서 결국 한번더 검사해주는 로직을 작성해야함
                           (value === DesireMajorValueEnum.SW ||

--- a/packages/ui/src/components/register/Step3Register/index.tsx
+++ b/packages/ui/src/components/register/Step3Register/index.tsx
@@ -2,11 +2,13 @@
 
 import { useEffect } from 'react';
 import {
+  Control,
   FormState,
+  UseFormGetValues,
   UseFormRegister,
   UseFormSetValue,
   UseFormTrigger,
-  UseFormWatch,
+  useWatch,
 } from 'react-hook-form';
 
 import { RelationshipWithGuardianValueEnum, Step3FormType } from '@repo/types';
@@ -18,7 +20,8 @@ import { Input } from '../../../shadcn';
 interface Step3RegisterProps {
   register: UseFormRegister<Step3FormType>;
   setValue: UseFormSetValue<Step3FormType>;
-  watch: UseFormWatch<Step3FormType>;
+  control: Control<Step3FormType>;
+  getValues: UseFormGetValues<Step3FormType>;
   trigger: UseFormTrigger<Step3FormType>;
   formState: FormState<Step3FormType>;
   isCandidate: boolean;
@@ -33,12 +36,20 @@ const relationshipWithGuardianList = [
 const Step3Register = ({
   register,
   setValue,
-  watch,
+  control,
+  getValues,
   trigger,
   formState: { errors },
   isCandidate,
   showError,
 }: Step3RegisterProps) => {
+  // 렌더 중 구독은 watch() 대신 useWatch 사용 (React Compiler 호환)
+  const relationshipWithGuardian = useWatch({ control, name: 'relationshipWithGuardian' });
+  const otherRelationshipWithGuardian = useWatch({
+    control,
+    name: 'otherRelationshipWithGuardian',
+  });
+
   const handleRelationshipWithGuardianOptionClick = (value: RelationshipWithGuardianValueEnum) => {
     if (value !== RelationshipWithGuardianValueEnum.OTHER) {
       setValue('otherRelationshipWithGuardian', null);
@@ -49,8 +60,8 @@ const Step3Register = ({
 
   useEffect(() => {
     if (isCandidate) {
-      setValue('schoolTeacherName', watch('schoolTeacherName') ?? '');
-      setValue('schoolTeacherPhoneNumber', watch('schoolTeacherPhoneNumber') ?? '');
+      setValue('schoolTeacherName', getValues('schoolTeacherName') ?? '');
+      setValue('schoolTeacherPhoneNumber', getValues('schoolTeacherPhoneNumber') ?? '');
     }
 
     if (!isCandidate) {
@@ -105,19 +116,18 @@ const Step3Register = ({
             <RadioButton<RelationshipWithGuardianValueEnum>
               title={'보호자 관계'}
               list={[...relationshipWithGuardianList]}
-              selectedValue={watch('relationshipWithGuardian')}
+              selectedValue={relationshipWithGuardian}
               handleOptionClick={handleRelationshipWithGuardianOptionClick}
               error={showError}
               required
             />
-            {watch('relationshipWithGuardian') === RelationshipWithGuardianValueEnum.OTHER && (
+            {relationshipWithGuardian === RelationshipWithGuardianValueEnum.OTHER && (
               <Input
                 placeholder="직접 입력"
                 {...register('otherRelationshipWithGuardian')}
                 variant={
                   showError &&
-                  (errors.otherRelationshipWithGuardian ||
-                    watch('otherRelationshipWithGuardian') === null)
+                  (errors.otherRelationshipWithGuardian || otherRelationshipWithGuardian === null)
                     ? 'error'
                     : null
                 }

--- a/packages/ui/src/components/register/Step4Register/index.tsx
+++ b/packages/ui/src/components/register/Step4Register/index.tsx
@@ -7,11 +7,11 @@ import {
   UseFormRegister,
   UseFormSetValue,
   UseFormUnregister,
-  UseFormWatch,
   UseFormStateReturn,
   UseFormTrigger,
   UseFormGetValues,
   get,
+  useWatch,
 } from 'react-hook-form';
 
 import { GENERAL_SUBJECTS } from '@repo/constants';
@@ -116,7 +116,6 @@ interface Step4RegisterProps {
   register: UseFormRegister<Step4FormType>;
   unregister: UseFormUnregister<Step4FormType>;
   setValue: UseFormSetValue<Step4FormType>;
-  watch: UseFormWatch<Step4FormType>;
   trigger: UseFormTrigger<Step4FormType>;
   getValues: UseFormGetValues<Step4FormType>;
   control: Control<Step4FormType>;
@@ -132,7 +131,6 @@ const Step4Register = ({
   register,
   setValue,
   control,
-  watch,
   trigger,
   formState,
   unregister,
@@ -148,9 +146,14 @@ const Step4Register = ({
   const [subjectArray, setSubjectArray] = useState<string[]>([...GENERAL_SUBJECTS]);
   const defaultSubjectLength = GENERAL_SUBJECTS.length;
 
+  // 렌더 중 구독은 watch() 대신 useWatch 사용 (React Compiler 호환)
+  const liberalSystem = useWatch({ control, name: 'liberalSystem' });
+  const freeSemester = useWatch({ control, name: 'freeSemester' });
+  const gedAvgScore = useWatch({ control, name: 'gedAvgScore' });
+
   const isCalculate = type === 'calculate';
-  const isFreeSemester = watch('liberalSystem') === LiberalSystemValueEnum.FREE_SEMESTER;
-  const isFreeGrade = watch('liberalSystem') === LiberalSystemValueEnum.FREE_GRADE;
+  const isFreeSemester = liberalSystem === LiberalSystemValueEnum.FREE_SEMESTER;
+  const isFreeGrade = liberalSystem === LiberalSystemValueEnum.FREE_GRADE;
 
   const achievementList: AchievementType[] = isFreeSemester
     ? isCandidate
@@ -171,13 +174,14 @@ const Step4Register = ({
     unregister(`achievement3_2.${idx}`, undefined);
     setSubjectArray(filteredSubjects);
 
-    const newSubjects = watch('newSubjects');
-    const score1_1 = watch('achievement1_1');
-    const score1_2 = watch('achievement1_2');
-    const score2_1 = watch('achievement2_1');
-    const score2_2 = watch('achievement2_2');
-    const score3_1 = watch('achievement3_1');
-    const score3_2 = watch('achievement3_2');
+    // 이벤트 핸들러에서는 구독이 불필요 — getValues() 사용 (React Compiler 호환)
+    const newSubjects = getValues('newSubjects');
+    const score1_1 = getValues('achievement1_1');
+    const score1_2 = getValues('achievement1_2');
+    const score2_1 = getValues('achievement2_1');
+    const score2_2 = getValues('achievement2_2');
+    const score3_1 = getValues('achievement3_1');
+    const score3_2 = getValues('achievement3_2');
 
     setValue(
       'newSubjects',
@@ -197,15 +201,15 @@ const Step4Register = ({
       : `추가과목 ${subjectArray.length - defaultSubjectLength}`;
     setSubjectArray((prev) => [...prev, newSubject]);
 
-    if (watch('liberalSystem') === LiberalSystemValueEnum.FREE_GRADE) {
+    if (getValues('liberalSystem') === LiberalSystemValueEnum.FREE_GRADE) {
       achievementList.forEach(({ field }) =>
-        setValue(`${field}.${subjectArray.length}`, watch(`${field}.${subjectArray.length}`)),
+        setValue(`${field}.${subjectArray.length}`, getValues(`${field}.${subjectArray.length}`)),
       );
     } else {
       achievementList.forEach(
         ({ field, value }) =>
-          value !== watch('freeSemester') &&
-          setValue(`${field}.${subjectArray.length}`, watch(`${field}.${subjectArray.length}`)),
+          value !== getValues('freeSemester') &&
+          setValue(`${field}.${subjectArray.length}`, getValues(`${field}.${subjectArray.length}`)),
       );
     }
   };
@@ -226,10 +230,10 @@ const Step4Register = ({
       setValue('freeSemester', null);
     } else {
       setValue('gedAvgScore', null);
-      setValue('liberalSystem', watch('liberalSystem') || LiberalSystemValueEnum.FREE_GRADE);
+      setValue('liberalSystem', getValues('liberalSystem') || LiberalSystemValueEnum.FREE_GRADE);
     }
 
-    const newSubject = watch('newSubjects');
+    const newSubject = getValues('newSubjects');
 
     if (newSubject && newSubject.length) {
       newSubject.forEach((subjectName) => handleAddSubjectClick(subjectName));
@@ -315,8 +319,7 @@ const Step4Register = ({
                   input.value = input.value.replace(/[^0-9.]/g, '').replace(/(\..*?)\..*/g, '$1');
                 }}
                 variant={
-                  (Boolean(get(formState.errors, 'gedAvgScore')) ||
-                    watch('gedAvgScore') === undefined) &&
+                  (Boolean(get(formState.errors, 'gedAvgScore')) || gedAvgScore === undefined) &&
                   showError
                     ? 'error'
                     : null
@@ -353,7 +356,7 @@ const Step4Register = ({
                   'flex-col',
                   'gap-[2.5rem]',
                   'items-center',
-                  widthConvertor[`${watch('liberalSystem')}_${graduationType}`],
+                  widthConvertor[`${liberalSystem}_${graduationType}`],
                 )}
               >
                 <div className={cn([...formWrapper])}>
@@ -364,7 +367,6 @@ const Step4Register = ({
                       register={register}
                       setValue={setValue}
                       subjectArray={subjectArray}
-                      watch={watch}
                       control={control}
                       errors={formState.errors}
                       handleDeleteSubjectClick={handleDeleteSubjectClick}
@@ -380,10 +382,10 @@ const Step4Register = ({
                       register={register}
                       setValue={setValue}
                       subjectArray={subjectArray}
-                      watch={watch}
+                      control={control}
                       errors={formState.errors}
                       handleDeleteSubjectClick={handleDeleteSubjectClick}
-                      freeSemester={watch('freeSemester')}
+                      freeSemester={freeSemester}
                       isGraduate={isGraduate}
                       showError={showError}
                       getValues={getValues}
@@ -416,12 +418,12 @@ const Step4Register = ({
                   <ArtPhysicalForm
                     graduationType={graduationType}
                     setValue={setValue}
-                    watch={watch}
+                    control={control}
                     isFreeGrade={isFreeGrade}
                     isFreeSemester={isFreeSemester}
                     isGraduate={isGraduate}
                     showError={showError}
-                    freeSemester={watch('freeSemester')}
+                    freeSemester={freeSemester}
                   />
                 </div>
                 <div id="nonSubject" className={cn([...formWrapper])}>


### PR DESCRIPTION
## 개요 💡

원서접수 step2에서 "지원자 유형"·"전형" 라디오를 클릭해도 선택 표시가 되지 않는 문제를 수정합니다. local·stage 양쪽에서 재현됐습니다.

원인은 #432에서 켠 `reactCompiler: true`입니다. React Compiler는 함수 호출을 순수하다고 가정해 결과를 메모이즈하는데, RHF의 `watch()`는 내부 mutable 상태를 읽는 **비순수** 함수입니다. `watch`는 렌더 간 레퍼런스가 고정이라 컴파일러가 만든 가드가 영원히 false가 되고, 호출 결과가 첫 렌더 값에 얼어붙습니다.

폼 값 자체는 `setValue`로 정상 저장되므로 **화면 반영 경로만 끊긴 상태**였습니다.

#432의 stage-5(`cfd74c26`)에서 `StepWrapper`·`CalculatePage`·`ApplicantTR`은 `useWatch`/`getValues`로 정리했지만, Step1~4와 하위 폼은 `watch`를 **props로 받기 때문에** `react-hooks/incompatible-library`가 탐지하지 못해 그대로 남아 있었습니다. 해당 룰은 `useForm().watch` 형태를 어휘적으로만 탐지합니다.

## 작업내용 ⌨️

**1. 잔여 8개 컴포넌트 전환** (`packages/ui`)

`Step1~4Register`, `UploadPhoto`, `FreeGradeForm`, `FreeSemesterForm`, `ArtPhysicalForm`

- 렌더 중 구독 `watch()` → `useWatch({ control, name })`
- 이벤트 핸들러·effect 내 `watch()` → `getValues()` (구독 불필요)
- props에서 `watch` 제거하고 `control`·`getValues` 전달. 호출부(`StepWrapper`, `CalculatePage`)는 `{...stepNUseForm}` 스프레드라 **변경 없음**
- `.map()` 안 동적 필드명(`` watch(`${field}.${idx}`) ``)은 훅을 루프에서 호출할 수 없어, `ACHIEVEMENT_FIELD_LIST`·`artsPhysicalAchievement` 배열을 최상단에서 한 번 구독 후 인덱싱

**2. 재발 방지 룰 추가** (`packages/eslint-config`)

`no-restricted-syntax`로 prop 타입 선언의 `UseFormWatch`를 금지합니다. `react-internal`·`next` 양쪽 설정에 연결했습니다.

## 함께 고쳐진 것 — step2 학교찾기

`isGED`도 같은 이유로 얼어붙어 있었습니다. 수정 전 산출물에서 `isCandidate`는 매 렌더 실행되는 반면 `isGED`만 캐시됐습니다:

```js
const isCandidate = watch("graduationType") === ...CANDIDATE;  // 정상
const isGED = t6 === ...GED;                                   // t6 = 캐시된 초기값
```

`isGED`가 `false`에 고정되면서 검정고시 선택 시:

- `!isGED && <Input 내 중학교 찾기 /> + SearchDialog` → **학교찾기 UI가 그대로 남음**
- 라벨이 "검정고시 합격일"로 안 바뀜
- `!isGED && <학년/반/번호>` → 검정고시인데 반/번호 칸이 계속 노출

동시에 `handleGraduationTypeOptionClick`은 `schoolName`/`schoolAddress`를 `null`로 지우므로, **입력칸은 보이는데 폼 값은 null**인 상태가 되어 원인 표시 없이 검증에 걸렸습니다.

`SearchDialog` 자체에는 문제가 없었습니다(`watch` 미사용, 컴파일 산출물 확인).

## 검증 ✅

- `pnpm check-types` 9/9
- `pnpm lint` 9/9, **0 errors** (기존 `exhaustive-deps` warning만 잔존)
- `pnpm build` 10/10, `pnpm test:e2e` 6/6
- **컴파일러 산출물 직접 확인** — 8개 파일 모두 bailout 없이 컴파일되며 `!== watch` 가드 0건. step2 라디오 JSX 메모가 이제 실제 값에 키잉됨:
  ```js
  if ($[59] !== graduationType || $[60] !== handleGraduationTypeOptionClick || $[61] !== showError)
  ```
- **실동작 확인** — `/register`가 로그인 게이트라 실제 `Step2Register`를 마운트하는 임시 라우트를 띄워 Playwright로 검증 (확인 후 삭제):
  - 지원자 유형·전형 라디오 `checked` 반영
  - 학교명 검색 → 선택 시 입력칸 DOM 값 + 폼 값(`schoolName`·`schoolAddress`) 반영, 재검색도 정상
  - 졸업예정 → 졸업자 → 검정고시 → 졸업예정 왕복 시 학교찾기 영역 숨김/복귀·라벨 전환 정상
  - DOM 렌더 루프 0건
- `/oneseo/calculate`에서 step4 성적 select 실제 반영 확인

## 리뷰 요청사항 👀

- 직접 실행하여 코드가 잘 적용되었는지 확인 부탁드립니다.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MehbREHKvPhQS3bNe9UK5V
