### PR TITLE
[feat] 원서 작성 중 자동 임시저장 (단계 이동 시 + step 4 유휴 2분)

### DIFF
--- a/packages/ui/src/components/StepBar/index.tsx
+++ b/packages/ui/src/components/StepBar/index.tsx
@@ -55,6 +55,7 @@ interface StepBarType {
   };
   handleStepError: (step: StepEnum) => void;
   handlePreviewPrint?: () => void;
+  handleAutoTempSave?: () => void;
 }
 
 const StepBar = ({
@@ -64,6 +65,7 @@ const StepBar = ({
   handleCheckScoreButtonClick,
   handleStepError,
   handlePreviewPrint,
+  handleAutoTempSave,
 }: StepBarType) => {
   const { push } = useRouter();
 
@@ -71,6 +73,9 @@ const StepBar = ({
 
   const handleCheckNextStep = (step: StepEnum) => {
     if (!isStepSuccess[step]) return handleStepError(step);
+
+    // 저장 완료를 기다리지 않고 바로 이동한다 (soft navigation이라 요청은 그대로 진행됨)
+    handleAutoTempSave?.();
 
     push(`${baseUrl}?step=${Number(step) + 1}`);
   };

--- a/packages/ui/src/components/StepWrapper/index.tsx
+++ b/packages/ui/src/components/StepWrapper/index.tsx
@@ -396,10 +396,23 @@ const StepWrapper = ({ data, step, info, memberId, type, isModifyApproved }: Ste
     }
   };
 
-  const handleTemporarySaveButtonClick = () => {
+  // 직전에 임시저장에 성공한 payload — 동일한 내용의 중복 저장 요청을 걸러내는 데 사용
+  const lastSavedTempBodyRef = useRef<string | null>(null);
+
+  const getTempStorage = () => {
     const body = getOneseo(true);
 
-    postTempStorage(body);
+    return { body, key: JSON.stringify(body) };
+  };
+
+  const handleTemporarySaveButtonClick = () => {
+    const { body, key } = getTempStorage();
+
+    postTempStorage(body, {
+      onSuccess: () => {
+        lastSavedTempBodyRef.current = key;
+      },
+    });
   };
 
   const handleOneseoEditButtonClick = async () => {

--- a/packages/ui/src/components/StepWrapper/index.tsx
+++ b/packages/ui/src/components/StepWrapper/index.tsx
@@ -437,14 +437,29 @@ const StepWrapper = ({ data, step, info, memberId, type, isModifyApproved }: Ste
     idleTimerRef.current = null;
   };
 
+  // 지금 입력값을 기준으로 2분 타이머를 새로 건다. 대기 중이던 타이머는 여기서 버린다.
+  const armIdleTimer = () => {
+    if (!isClient || !isStep4 || isIdleTimerStoppedRef.current) return;
+
+    clearIdleTimer();
+
+    idleTimerRef.current = setTimeout(() => {
+      idleTimerRef.current = null;
+      handleAutoTempSave();
+    }, IDLE_AUTO_SAVE_DELAY);
+  };
+
   const stopIdleTimer = () => {
     isIdleTimerStoppedRef.current = true;
     clearIdleTimer();
   };
 
-  // 제출이 끝내 실패했다면 아직 작성 중인 원서이므로 자동저장을 되살린다
+  // 제출이 끝내 실패했다면 아직 작성 중인 원서이므로 자동저장을 되살린다.
+  // 플래그만 열어두면 타이머는 없는 채로 남는다 — 재장전은 입력이 바뀔 때만 일어나는데
+  // 제출 실패 후 사용자가 폼을 더 건드리지 않으면 그 시점이 오지 않기 때문이다.
   const resumeIdleTimer = () => {
     isIdleTimerStoppedRef.current = false;
+    armIdleTimer();
   };
 
   const handleTemporarySaveButtonClick = () => {
@@ -474,7 +489,11 @@ const StepWrapper = ({ data, step, info, memberId, type, isModifyApproved }: Ste
   const observedStep4ValuesRef = useRef<string | null>(null);
 
   useEffect(() => {
-    if (!isClient || !isStep4 || isIdleTimerStoppedRef.current) return;
+    // step 4를 벗어났거나 자동저장이 멈춘 상태면 대기 중인 타이머만 정리한다
+    if (!isClient || !isStep4 || isIdleTimerStoppedRef.current) {
+      clearIdleTimer();
+      return;
+    }
 
     const step4ValuesKey = JSON.stringify(step4Values);
     const hasEdited =
@@ -482,19 +501,19 @@ const StepWrapper = ({ data, step, info, memberId, type, isModifyApproved }: Ste
 
     observedStep4ValuesRef.current = step4ValuesKey;
 
-    // step 4 진입만으로는 타이머를 걸지 않는다 — 직전 '다음으로'가 이미 저장했다
+    // step 4 진입만으로는 타이머를 걸지 않는다 — 직전 '다음으로'가 이미 저장했다.
+    // 값이 그대로인 알림(이미 선택된 값 재선택 등)이라면 대기 중인 타이머를 건드리지 않는다.
     if (!hasEdited) return;
 
-    idleTimerRef.current = setTimeout(() => {
-      idleTimerRef.current = null;
-      handleAutoTempSave();
-    }, IDLE_AUTO_SAVE_DELAY);
-
-    // 입력이 이어지면 이전 타이머를 버리고 다시 2분을 센다
-    return clearIdleTimer;
+    // 입력이 이어지면 armIdleTimer가 이전 타이머를 버리고 다시 2분을 센다
+    armIdleTimer();
     // handleAutoTempSave는 렌더마다 새로 만들어지므로 의존성에 넣으면 타이머가
     // 매 렌더 초기화돼 만료되지 않는다. 입력 변화에만 반응해야 하므로 의도적으로 제외한다.
   }, [step4Values, isStep4, isClient]);
+
+  // 타이머 정리는 언마운트 시에만 한다. 위 effect의 cleanup으로 두면 값이 바뀌지 않은
+  // 재실행에서도 대기 중인 타이머가 취소되고, hasEdited가 false라 재장전되지 않는다.
+  useEffect(() => clearIdleTimer, []);
 
   const handleOneseoEditButtonClick = async () => {
     await patchPersonalInfoByMemberId(getPersonalInfo());

--- a/packages/ui/src/components/StepWrapper/index.tsx
+++ b/packages/ui/src/components/StepWrapper/index.tsx
@@ -417,7 +417,20 @@ const StepWrapper = ({ data, step, info, memberId, type, isModifyApproved }: Ste
     lastSavedTempBodyRef.current = null;
   };
 
+  const idleTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const clearIdleTimer = () => {
+    if (idleTimerRef.current === null) return;
+
+    clearTimeout(idleTimerRef.current);
+    idleTimerRef.current = null;
+  };
+
   const handleTemporarySaveButtonClick = () => {
+    // 버튼이 지금 저장하므로 대기 중인 자동저장 타이머는 불필요하다.
+    // 이후 추가 입력이 있으면 타이머는 다시 2분으로 걸린다.
+    clearIdleTimer();
+
     const { body, key } = getTempStorage();
 
     lastSavedTempBodyRef.current = key;
@@ -435,17 +448,9 @@ const StepWrapper = ({ data, step, info, memberId, type, isModifyApproved }: Ste
     autoSaveTempStorage(body, { onError: rollbackLastSavedTempBody });
   };
 
-  const idleTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   // 직전에 관찰한 step 4 입력값 — 실제로 값이 바뀐 경우에만 타이머를 걸기 위해 사용.
   // 이 값이 없으면 step 4에 처음 도착한 시점이라 아직 사용자 입력이 없다는 뜻이다.
   const observedStep4ValuesRef = useRef<string | null>(null);
-
-  const clearIdleTimer = () => {
-    if (idleTimerRef.current === null) return;
-
-    clearTimeout(idleTimerRef.current);
-    idleTimerRef.current = null;
-  };
 
   useEffect(() => {
     if (!isClient || !isStep4) return;

--- a/packages/ui/src/components/StepWrapper/index.tsx
+++ b/packages/ui/src/components/StepWrapper/index.tsx
@@ -1,5 +1,3 @@
- 
- 
 'use client';
 
 import { zodResolver } from '@hookform/resolvers/zod';
@@ -401,7 +399,8 @@ const StepWrapper = ({ data, step, info, memberId, type, isModifyApproved }: Ste
     }
   };
 
-  // 직전에 임시저장에 성공한 payload — 동일한 내용의 중복 저장 요청을 걸러내는 데 사용
+  // 직전에 임시저장을 요청한 payload — 동일한 내용의 중복 저장 요청을 걸러내는 데 사용.
+  // 응답이 아니라 요청 시점에 갱신해야 아직 응답이 오지 않은 저장과의 중복까지 막을 수 있다.
   const lastSavedTempBodyRef = useRef<string | null>(null);
 
   const getTempStorage = () => {
@@ -410,14 +409,17 @@ const StepWrapper = ({ data, step, info, memberId, type, isModifyApproved }: Ste
     return { body, key: JSON.stringify(body) };
   };
 
+  // 저장에 실패하면 서버에 반영되지 않았으므로 키를 되돌려 다음 시도를 허용한다
+  const rollbackLastSavedTempBody = () => {
+    lastSavedTempBodyRef.current = null;
+  };
+
   const handleTemporarySaveButtonClick = () => {
     const { body, key } = getTempStorage();
 
-    postTempStorage(body, {
-      onSuccess: () => {
-        lastSavedTempBodyRef.current = key;
-      },
-    });
+    lastSavedTempBodyRef.current = key;
+
+    postTempStorage(body, { onError: rollbackLastSavedTempBody });
   };
 
   const handleAutoTempSave = () => {
@@ -425,11 +427,9 @@ const StepWrapper = ({ data, step, info, memberId, type, isModifyApproved }: Ste
 
     if (lastSavedTempBodyRef.current === key) return;
 
-    autoSaveTempStorage(body, {
-      onSuccess: () => {
-        lastSavedTempBodyRef.current = key;
-      },
-    });
+    lastSavedTempBodyRef.current = key;
+
+    autoSaveTempStorage(body, { onError: rollbackLastSavedTempBody });
   };
 
   const handleOneseoEditButtonClick = async () => {

--- a/packages/ui/src/components/StepWrapper/index.tsx
+++ b/packages/ui/src/components/StepWrapper/index.tsx
@@ -237,6 +237,11 @@ const StepWrapper = ({ data, step, info, memberId, type, isModifyApproved }: Ste
     onError: () => toast.error('임시 저장을 실패하였습니다.'),
   });
 
+  // 단계 이동 시 자동 저장 전용 — 성공 토스트 없이 조용히 저장한다
+  const { mutate: autoSaveTempStorage } = usePostTempStorage(Number(step), {
+    onError: () => toast.error('임시 저장을 실패하였습니다.'),
+  });
+
   const { mutate: postMockScore } = usePostMockScore(graduationType, {
     onSuccess: (data) => {
       setScoreCalculationCompleteModal(true, data, 'score');
@@ -415,6 +420,18 @@ const StepWrapper = ({ data, step, info, memberId, type, isModifyApproved }: Ste
     });
   };
 
+  const handleAutoTempSave = () => {
+    const { body, key } = getTempStorage();
+
+    if (lastSavedTempBodyRef.current === key) return;
+
+    autoSaveTempStorage(body, {
+      onSuccess: () => {
+        lastSavedTempBodyRef.current = key;
+      },
+    });
+  };
+
   const handleOneseoEditButtonClick = async () => {
     await patchPersonalInfoByMemberId(getPersonalInfo());
     putOneseoByMemberId(getOneseo());
@@ -540,6 +557,7 @@ const StepWrapper = ({ data, step, info, memberId, type, isModifyApproved }: Ste
             handleCheckScoreButtonClick={handleCheckScoreButtonClick}
             handleStepError={handleStepError}
             handlePreviewPrint={isClient ? handlePreviewPrint : undefined}
+            handleAutoTempSave={isClient ? handleAutoTempSave : undefined}
           />
           <div
             className={cn(

--- a/packages/ui/src/components/StepWrapper/index.tsx
+++ b/packages/ui/src/components/StepWrapper/index.tsx
@@ -47,6 +47,9 @@ import EditBar from '../EditBar';
 import { Step1Register, Step2Register, Step3Register, Step4Register } from '../register';
 import StepBar from '../StepBar';
 
+/** step 4에서 마지막 입력 이후 이 시간만큼 입력이 없으면 자동으로 임시저장한다 */
+const IDLE_AUTO_SAVE_DELAY = 2 * 60 * 1000;
+
 interface StepWrapperProps {
   data: GetMyOneseoType | undefined;
   info?: MyMemberInfoType;
@@ -431,6 +434,41 @@ const StepWrapper = ({ data, step, info, memberId, type, isModifyApproved }: Ste
 
     autoSaveTempStorage(body, { onError: rollbackLastSavedTempBody });
   };
+
+  const idleTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  // 직전에 관찰한 step 4 입력값 — 실제로 값이 바뀐 경우에만 타이머를 걸기 위해 사용.
+  // 이 값이 없으면 step 4에 처음 도착한 시점이라 아직 사용자 입력이 없다는 뜻이다.
+  const observedStep4ValuesRef = useRef<string | null>(null);
+
+  const clearIdleTimer = () => {
+    if (idleTimerRef.current === null) return;
+
+    clearTimeout(idleTimerRef.current);
+    idleTimerRef.current = null;
+  };
+
+  useEffect(() => {
+    if (!isClient || !isStep4) return;
+
+    const step4ValuesKey = JSON.stringify(step4Values);
+    const hasEdited =
+      observedStep4ValuesRef.current !== null && observedStep4ValuesRef.current !== step4ValuesKey;
+
+    observedStep4ValuesRef.current = step4ValuesKey;
+
+    // step 4 진입만으로는 타이머를 걸지 않는다 — 직전 '다음으로'가 이미 저장했다
+    if (!hasEdited) return;
+
+    idleTimerRef.current = setTimeout(() => {
+      idleTimerRef.current = null;
+      handleAutoTempSave();
+    }, IDLE_AUTO_SAVE_DELAY);
+
+    // 입력이 이어지면 이전 타이머를 버리고 다시 2분을 센다
+    return clearIdleTimer;
+    // handleAutoTempSave는 렌더마다 새로 만들어지므로 의존성에 넣으면 타이머가
+    // 매 렌더 초기화돼 만료되지 않는다. 입력 변화에만 반응해야 하므로 의도적으로 제외한다.
+  }, [step4Values, isStep4, isClient]);
 
   const handleOneseoEditButtonClick = async () => {
     await patchPersonalInfoByMemberId(getPersonalInfo());

--- a/packages/ui/src/components/StepWrapper/index.tsx
+++ b/packages/ui/src/components/StepWrapper/index.tsx
@@ -392,13 +392,21 @@ const StepWrapper = ({ data, step, info, memberId, type, isModifyApproved }: Ste
   };
 
   const handleOneseoSubmitButtonClick = async () => {
-    await patchPersonalInfo(getPersonalInfo());
+    // 제출 요청 중에 자동저장이 나가면 서버의 제출 완료 상태가 다시 작성 중으로
+    // 되돌아간다. 요청을 보내기 전에 멈추고, 제출이 실패하면 되살린다.
+    stopIdleTimer();
+
+    await patchPersonalInfo(getPersonalInfo()).catch((error) => {
+      resumeIdleTimer();
+      throw error;
+    });
+
     const body = getOneseo();
 
     if (isModifyApproved) {
-      modifyMyOneseo(body);
+      modifyMyOneseo(body, { onError: resumeIdleTimer });
     } else {
-      postMyOneseo(body);
+      postMyOneseo(body, { onError: resumeIdleTimer });
     }
   };
 
@@ -418,12 +426,25 @@ const StepWrapper = ({ data, step, info, memberId, type, isModifyApproved }: Ste
   };
 
   const idleTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  // 최종 제출 이후에는 임시저장이 서버의 제출 완료 상태를 다시 작성 중으로 되돌리므로
+  // 자동저장을 영구히 멈춘다. 제출 성공 모달이 떠도 이 화면은 그대로 남아 있다.
+  const isIdleTimerStoppedRef = useRef(false);
 
   const clearIdleTimer = () => {
     if (idleTimerRef.current === null) return;
 
     clearTimeout(idleTimerRef.current);
     idleTimerRef.current = null;
+  };
+
+  const stopIdleTimer = () => {
+    isIdleTimerStoppedRef.current = true;
+    clearIdleTimer();
+  };
+
+  // 제출이 끝내 실패했다면 아직 작성 중인 원서이므로 자동저장을 되살린다
+  const resumeIdleTimer = () => {
+    isIdleTimerStoppedRef.current = false;
   };
 
   const handleTemporarySaveButtonClick = () => {
@@ -453,7 +474,7 @@ const StepWrapper = ({ data, step, info, memberId, type, isModifyApproved }: Ste
   const observedStep4ValuesRef = useRef<string | null>(null);
 
   useEffect(() => {
-    if (!isClient || !isStep4) return;
+    if (!isClient || !isStep4 || isIdleTimerStoppedRef.current) return;
 
     const step4ValuesKey = JSON.stringify(step4Values);
     const hasEdited =


### PR DESCRIPTION
## 개요 💡

원서 작성 중 임시저장이 **하단 `임시저장` 버튼을 직접 누를 때만** 동작합니다. 4개 step의 폼 상태(`useForm` 인스턴스 4개)는 메모리에만 있어서, 저장 버튼을 누르지 않은 채 탭을 닫거나 새로고침하면 입력이 전부 사라집니다. 현재 방어책은 `beforeunload` 경고 하나뿐입니다.

이 PR은 사용자가 저장을 의식하지 않아도 입력이 서버에 남도록 **자동 임시저장 2가지**를 추가합니다.

| 구간 | 저장 시점 |
| --- | --- |
| step 1 → 2 → 3 → 4 | `다음으로` 버튼으로 이동할 때 |
| step 4 | 마지막 입력으로부터 2분간 입력이 없을 때 |

step 4 다음은 최종 제출이라 `다음으로` 버튼이 없습니다(`내 성적 계산하기`로 대체). 이동 시 저장이 닿지 않는 유일한 구간이라 타이머로 커버합니다.

기존 자산을 그대로 재사용했고 **API 훅·엔드포인트·쿼리키 추가는 없습니다** — payload 빌더 `getOneseo(true)`와 `usePostTempStorage`(`POST /oneseo/v3/temp-storage?step={n}`)를 씁니다.

## 작업내용 ⌨️

### 1. 단계 이동 시 자동 임시저장

`StepBar`의 `handleCheckNextStep`에서 유효성 검사를 통과한 뒤 이동 직전에 저장을 호출합니다.

- **저장 완료를 기다리지 않습니다.** `push`는 같은 라우트의 soft navigation이라 `StepWrapper`가 언마운트되지 않고 진행 중인 요청은 그대로 완료됩니다. `await`하면 네트워크 지연만큼 화면 전환이 막힙니다.
- 유효성 실패 시엔 early return이라 불완전한 데이터가 전송되지 않습니다.
- **성공 시 토스트를 띄우지 않습니다.** 1→2→3→4로 넘어가며 성공 토스트가 3번 뜨는 걸 피하기 위해, 훅 레벨 성공 토스트가 없는 mutation 인스턴스를 따로 둡니다. (react-query의 per-call `options`는 훅 레벨 콜백을 대체하지 않고 함께 실행되므로 기존 인스턴스로는 토스트를 끌 수 없습니다.) 실패 시에만 알립니다.
- `StepBar`는 admin `/edit/[memberId]`와 공유되고 admin에는 임시저장 개념이 없어, 콜백을 client에서만 넘깁니다(`handlePreviewPrint`와 동일한 패턴).

### 2. step 4 유휴 2분 타이머

`step4Values`(이미 있던 `useWatch`) 변화에 반응하는 effect + `setTimeout`입니다. 입력이 이어지면 cleanup이 이전 타이머를 지우고 2분을 다시 셉니다.

- **step 4에서만 동작** — `isStep4`가 false면 early return이라 1~3단계에서는 타이머가 생성 자체를 안 합니다.
- **값이 실제로 바뀐 경우에만 arm** — 직전 값을 ref에 담아 비교합니다. step 4에 도착하거나(직전 `다음으로`가 방금 저장) 다시 돌아온 것만으로는 저장이 발생하지 않습니다.
- **`임시저장` 버튼 클릭 시 해제** — 버튼이 그 자리에서 저장하므로 대기 중이던 타이머까지 만료되면 같은 내용이 두 번 나갑니다. 클릭 시 해제하고, 이후 추가 입력이 있을 때만 다시 2분을 셉니다.
- step을 벗어나거나 언마운트되면 정리합니다.

`setInterval` 폴링이나 `sessionStorage` 방식은 택하지 않았습니다. 보여줄 카운트다운이 없어 1초 tick이 불필요하고, 새로고침되면 폼이 서버 draft로 다시 채워지므로 복원할 "저장 안 된 입력"이 존재하지 않습니다.

### 3. 중복 저장 방지

수동·이동·타이머 세 경로가 payload 직렬화 키 하나(`lastSavedTempBodyRef`)를 공유해, 직전 저장과 내용이 같으면 요청을 생략합니다.

키를 **요청 직전에** 갱신하고 실패 시 되돌립니다. 응답을 받은 뒤 갱신하면 응답을 기다리는 동안(예: `임시저장` 클릭 직후 타이머 만료) 같은 payload가 한 번 더 전송됩니다. mutation의 `isPending`으로는 막을 수 없습니다 — 수동/자동 인스턴스가 2개라 서로를 보지 못합니다.

### 4. 최종 제출 시 타이머 영구 정지 (버그 수정)

작업 중 발견한 문제입니다. 제출 성공 모달은 `확인`을 눌러야 `/mypage`로 이동하므로 **제출 직후에도 작성 화면이 그대로 마운트돼 있습니다.** 마지막 step 4 입력이 제출 2분 이내였다면 제출이 끝난 뒤 타이머가 만료돼 임시저장이 나가고, 서버의 `step`이 다시 채워져 **제출 완료 상태가 작성 중으로 되돌아갑니다.**

`step`은 draft 판별 플래그로 여러 곳에서 쓰입니다 — `register/page.tsx`의 진입 가드, `/guide`의 `원서 이어서 작성하기` 라벨, `/mypage`의 제출 완료 UI 노출 조건.

제출 요청을 보내기 **전에** 타이머를 멈추고 이후 재무장도 막되, 제출이 실패한 경우엔 아직 작성 중인 원서이므로 되살립니다(`patchPersonalInfo` 거절 경로 포함, 기존 rejection 전파는 그대로 유지).

## 변경 파일

- `packages/ui/src/components/StepWrapper/index.tsx` — 자동저장 mutation 인스턴스, 중복 방지, 타이머
- `packages/ui/src/components/StepBar/index.tsx` — `handleAutoTempSave?` prop 추가 및 `다음으로`에서 호출

## 검증 ✅

- `pnpm lint` **0 errors** (기존 `exhaustive-deps` warning만 잔존)
- `pnpm check-types` 9/9
- `pnpm build` 10/10

React Compiler 호환: 핸들러·effect만 추가했고 `watch` prop 전달이나 렌더 중 구독은 없습니다.

타이머 effect에서 `handleAutoTempSave`를 의존성에서 의도적으로 제외했습니다(주석 명시). 렌더마다 새로 만들어지는 함수라 넣으면 타이머가 매 렌더 초기화돼 영원히 만료되지 않습니다.

## 리뷰 요청사항 👀

- **로그인이 필요해 브라우저 실동작 확인을 하지 못했습니다.** 아래 항목 확인 부탁드립니다. 2분 대기가 번거로우면 `StepWrapper`의 `IDLE_AUTO_SAVE_DELAY`를 일시적으로 낮춰 확인하실 수 있습니다.
  - 단계 이동마다 `POST /api/oneseo/v3/temp-storage?step=N` 1회, 성공 토스트 없음
  - `이전`으로 갔다가 수정 없이 다시 `다음으로` → 요청 없음
  - step 4에서 값 수정 → 2분 후 저장 / 1분 후 또 수정하면 두 번째 입력 기준 2분에 저장
  - `임시저장` 클릭 후 아무것도 안 하고 2분 → 요청 없음 / 클릭 후 수정하면 2분 뒤 저장
  - **최종 제출 직후 모달을 띄운 채 2분 대기 → 요청이 없어야 함** (4번 항목 회귀 테스트)
- **2분이라는 간격이 적절한지** 의견 부탁드립니다.
- **`이전` 버튼에서는 저장하지 않도록 했습니다.** 이전 버튼은 유효성 검사를 통과하지 않아도 눌리므로 불완전한 데이터가 저장될 여지가 있어 제외했는데, 이쪽도 저장하는 게 나을지 의견 주시면 반영하겠습니다.
- step 1을 떠날 때 조건부로 도는 기존 `patchPersonalInfo` effect와 자동 임시저장이 동시에 나갈 수 있습니다. 두 요청 모두 같은 폼 값에서 만들어져 결과는 동일하므로 이번 PR에서는 건드리지 않았습니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
